### PR TITLE
feat: per-issue comment limit for posting services

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,15 @@ sequenceDiagram
         PostingService-->>ExceptionProcessor: DuplicateSearchResult
 
         alt duplicate found
-            ExceptionProcessor->>PostingService: commentOnIssue(issueId, event)
-            PostingService-->>ExceptionProcessor: PostingResult
+            alt count < maxDuplicateComments
+                ExceptionProcessor->>PostingService: commentOnIssue(issueId, event)
+                PostingService-->>ExceptionProcessor: PostingResult
+            else count == maxDuplicateComments
+                ExceptionProcessor->>PostingService: postCommentLimitNotice(issueId, limit)
+                PostingService-->>ExceptionProcessor: PostingResult
+            else count > maxDuplicateComments
+                Note right of ExceptionProcessor: drop — increment<br/>observarium.comments.dropped
+            end
         else no duplicate
             ExceptionProcessor->>PostingService: createIssue(event)
             PostingService-->>ExceptionProcessor: PostingResult
@@ -165,12 +172,12 @@ All posting modules use the JDK built-in `java.net.http.HttpClient` and Gson —
 
 ## Posting Service Feature Matrix
 
-| Service | Create issue | Deduplication | Comment on duplicate |
-|---|---|---|---|
-| GitHub | Yes | Yes — label-based search | Yes |
-| Jira | Yes | Yes — JQL label search | Yes |
-| GitLab | Yes | Yes — label-based search | Yes |
-| Email | Yes | No | No |
+| Service | Create issue | Deduplication | Comment on duplicate | Comment limit |
+|---|---|---|---|---|
+| GitHub | Yes | Yes — label-based search | Yes | Yes |
+| Jira | Yes | Yes — JQL label search | Yes | Yes |
+| GitLab | Yes | Yes — label-based search | Yes | Yes |
+| Email | Yes | No | No | N/A |
 
 ## Documentation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ All configuration for a plain Java setup goes through the fluent builder returne
 | `postingServices(List<PostingService>)` | `List<PostingService>` | — | Replaces the entire posting service list at once. |
 | `listener(ObservariumListener)` | `ObservariumListener` | no-op | Registers a lifecycle listener that receives callbacks for exception captures, drops, and posting outcomes. Used by `observarium-micrometer` to bridge events to Micrometer meters. See [ObservariumListener](#observariumlistener). |
 | `queueCapacity(int)` | `int` | `256` | Capacity of the bounded `ArrayBlockingQueue` that backs the single background worker thread. When the queue is full, new events are dropped and a warning is logged. |
+| `maxDuplicateComments(int)` | `int` | `5` | Maximum number of duplicate comments posted on a single existing issue before further recurrences are dropped silently. Use `-1` for unlimited. See [Duplicate Comment Limit](#duplicate-comment-limit). |
 
 **Minimum working example:**
 
@@ -60,6 +61,7 @@ All properties are under the `observarium` prefix. Use either `application.yml` 
 | `observarium.email.password` | `String` | — | SMTP authentication password. |
 | `observarium.email.auth` | `boolean` | `true` | Enable SMTP authentication. |
 | `observarium.email.start-tls` | `boolean` | `true` | Enable STARTTLS. |
+| `observarium.max-duplicate-comments` | `int` | `5` | Maximum number of duplicate comments posted on a single existing issue. Use `-1` for unlimited. See [Duplicate Comment Limit](#duplicate-comment-limit). |
 
 **Example `application.yml`:**
 
@@ -83,7 +85,7 @@ observarium:
 
 Identical keys to Spring Boot; use `application.properties` or `application.yaml`.
 
-The Quarkus module uses the same property names as the Spring Boot module. Refer to the Spring Boot table above for the complete list.
+The Quarkus module uses the same property names as the Spring Boot module, including `observarium.max-duplicate-comments`. Refer to the Spring Boot table above for the complete list.
 
 **Example `application.properties`:**
 
@@ -318,3 +320,57 @@ Observarium obs = Observarium.builder()
 ```
 
 The primary built-in use of this interface is `ObservariumMeterBinder` from `observarium-micrometer`, which bridges these callbacks to Micrometer meters. See [Micrometer Integration](micrometer.md) for setup details.
+
+---
+
+## Duplicate Comment Limit
+
+When an exception recurs frequently, Observarium caps the number of duplicate comments posted on an existing issue to prevent issue tracker noise.
+
+### Behaviour by threshold
+
+For each duplicate occurrence, `ExceptionProcessor` retrieves the current comment count from `DuplicateSearchResult` and compares it against `maxDuplicateComments`:
+
+| Condition | Action |
+|---|---|
+| `commentCount < maxDuplicateComments` | Normal `commentOnIssue` call — the recurrence is appended to the issue. |
+| `commentCount == maxDuplicateComments` | `postCommentLimitNotice` is called once — a final "Comment Limit Reached" notice is posted on the issue. |
+| `commentCount > maxDuplicateComments` | The occurrence is dropped silently. `observarium.comments.dropped` counter is incremented. `ObservariumListener.onCommentDropped(serviceName)` is called. |
+
+> **Note:** The notice itself is an additional comment, so the total number of comments Observarium may post is `maxDuplicateComments + 1` (N regular comments plus the final notice). For example, with `maxDuplicateComments=5`, up to 6 comments may appear on the issue: 5 duplicate occurrence comments and 1 limit notice.
+
+### Comment count source
+
+The comment count is read from the tracker API during `findDuplicate()`:
+
+| Backend | API field |
+|---|---|
+| GitHub | `comments` field on the issue JSON |
+| GitLab | `user_notes_count` field on the issue JSON |
+| Jira | `fields.comment.total` from the issue response |
+
+The count reflects **all comments on the issue**, not just those posted by Observarium. This means comments left by human users, bots, or other integrations also count toward the limit. This is intentional: if an issue already has significant discussion, additional automated noise is unwanted regardless of who posted the existing comments.
+
+> **GitLab caveat:** GitLab's `user_notes_count` includes system-generated notes (label changes, milestone updates, etc.) in addition to user comments. This means the limit may trigger earlier than expected on issues with frequent label or milestone activity.
+
+### Custom posting services and fail-open behaviour
+
+`DuplicateSearchResult.found(id, url)` (the 2-argument form) returns `COMMENT_COUNT_UNKNOWN = -1` for the comment count. When `ExceptionProcessor` sees `-1`, it treats the count as below the limit and always allows the comment through. This means custom `PostingService` implementations that have not been updated to return a comment count continue to work without restriction. See [Custom Posting Service](custom-posting-service.md#duplicatesearchresult) for how to supply the count.
+
+### Configuration example
+
+**Plain Java builder:**
+
+```java
+Observarium obs = Observarium.builder()
+    .maxDuplicateComments(10)          // cap at 10 comments per issue
+    // .maxDuplicateComments(-1)       // unlimited
+    .addPostingService(new GitHubPostingService(GitHubConfig.of(token, "owner", "repo")))
+    .build();
+```
+
+**Spring Boot / Quarkus property:**
+
+```properties
+observarium.max-duplicate-comments=10
+```

--- a/docs/custom-posting-service.md
+++ b/docs/custom-posting-service.md
@@ -34,6 +34,15 @@ public interface PostingService {
      * externalIssueId is the value from the DuplicateSearchResult returned by findDuplicate().
      */
     PostingResult commentOnIssue(String externalIssueId, ExceptionEvent event);
+
+    /**
+     * Post a one-time "Comment Limit Reached" notice on the issue when the duplicate comment
+     * count equals maxDuplicateComments. Called at most once per issue per limit cycle.
+     * The default returns failure; override in backends that support issue comments.
+     */
+    default PostingResult postCommentLimitNotice(String externalIssueId, int commentLimit) {
+        return PostingResult.failure("postCommentLimitNotice not implemented by " + name());
+    }
 }
 ```
 
@@ -66,12 +75,15 @@ PostingResult.success("ISSUE-42", "https://example.com/issues/42");
 PostingResult.failure("HTTP 429: rate limit exceeded");
 ```
 
-**`DuplicateSearchResult`** — return value for `findDuplicate`:
+**`DuplicateSearchResult`** — return value for `findDuplicate`: <a name="duplicatesearchresult"></a>
 
 ```java
-DuplicateSearchResult.notFound();                                         // no duplicate
-DuplicateSearchResult.found("ISSUE-42", "https://example.com/issues/42"); // duplicate exists
+DuplicateSearchResult.notFound();
+DuplicateSearchResult.found("ISSUE-42", "https://example.com/issues/42");      // comment count unknown
+DuplicateSearchResult.found("ISSUE-42", "https://example.com/issues/42", 7);   // 7 comments on issue
 ```
+
+The 2-argument form returns `COMMENT_COUNT_UNKNOWN = -1`, which causes fail-open behaviour: `ExceptionProcessor` treats the count as below the configured limit and always allows the comment through. Supply the actual count via the 3-argument form to enable the comment limit for your backend.
 
 ### Deduplication strategy recommendations
 
@@ -79,6 +91,7 @@ DuplicateSearchResult.found("ISSUE-42", "https://example.com/issues/42"); // dup
 - **Search only open/active issues** — if a duplicate issue was closed or resolved, creating a fresh issue is usually the right behaviour.
 - **Fail safe to `notFound()`** — if the search API returns an error, return `DuplicateSearchResult.notFound()` so a new issue is created rather than swallowing the event.
 - **No dedup? Return `notFound()` always** — backends like email cannot search previous messages; returning `notFound()` unconditionally is correct for them.
+- **Return the comment count** — if your backend's search API returns a comment count on the existing issue, pass it as the third argument to `DuplicateSearchResult.found()`. This enables the `maxDuplicateComments` cap. Omitting the count causes fail-open behaviour (unlimited comments), which is safe but bypasses the limit.
 
 ---
 

--- a/docs/micrometer.md
+++ b/docs/micrometer.md
@@ -14,6 +14,7 @@ This module is a metrics facade only — it records numbers via Micrometer's API
 | `observarium.exceptions.dropped` | Counter | — | Exceptions dropped because the processing queue was full |
 | `observarium.queue.size` | Gauge | — | Current number of exceptions in the processing queue |
 | `observarium.posting.duration` | Timer | `service`, `action` (`create`/`comment`), `outcome` (`success`/`failure`) | Wall-clock time for each posting service call, including the duplicate search |
+| `observarium.comments.dropped` | Counter | `service` | Duplicate comments suppressed because the issue reached its comment limit |
 
 The `severity` tag value on `observarium.exceptions.captured` is the lowercase name of the `Severity` enum: `info`, `warning`, `error`, or `fatal`.
 
@@ -134,6 +135,7 @@ curl http://localhost:8080/actuator/metrics/observarium.exceptions.captured
 curl http://localhost:8080/actuator/metrics/observarium.exceptions.dropped
 curl http://localhost:8080/actuator/metrics/observarium.queue.size
 curl http://localhost:8080/actuator/metrics/observarium.posting.duration
+curl http://localhost:8080/actuator/metrics/observarium.comments.dropped
 ```
 
 To expose the metrics endpoint, add the following to `application.yml` if it is not already exposed:
@@ -261,5 +263,6 @@ Each unique combination of tags creates one meter entry in the registry. For the
 - `observarium.exceptions.dropped` — exactly one entry, no tags.
 - `observarium.queue.size` — exactly one entry, no tags.
 - `observarium.posting.duration` — one entry per combination of `service` × `action` × `outcome`. With two actions (`create`, `comment`) and two outcomes (`success`, `failure`), each posting service contributes at most 4 timer series. The total is bounded by the number of configured posting services multiplied by 4.
+- `observarium.comments.dropped` — one entry per posting service name. Bounded by the number of configured posting services.
 
 The total meter count is small and fixed at startup for any given configuration. There is no risk of cardinality explosion from normal use.

--- a/observarium-core/src/main/java/io/hephaistos/observarium/Observarium.java
+++ b/observarium-core/src/main/java/io/hephaistos/observarium/Observarium.java
@@ -268,6 +268,7 @@ public final class Observarium {
     private TraceContextProvider traceProvider;
     private final List<PostingService> postingServices = new ArrayList<>();
     private int queueCapacity = DEFAULT_QUEUE_CAPACITY;
+    private int maxDuplicateComments = ObservariumConfig.DEFAULT_MAX_DUPLICATE_COMMENTS;
     private ObservariumListener listener;
 
     /**
@@ -399,6 +400,30 @@ public final class Observarium {
     }
 
     /**
+     * Sets the maximum number of duplicate comments Observarium will post on a single issue before
+     * stopping. After the limit is reached, one final notice comment is posted and subsequent
+     * occurrences are silently dropped (tracked via the {@code observarium.comments.dropped}
+     * metric).
+     *
+     * <p>Defaults to {@value ObservariumConfig#DEFAULT_MAX_DUPLICATE_COMMENTS}. Use {@link
+     * ObservariumConfig#UNLIMITED_COMMENTS} ({@code -1}) for no limit (preserves pre-feature
+     * behavior).
+     *
+     * @param maxDuplicateComments the maximum comment count; must be {@code -1} (unlimited) or a
+     *     positive integer
+     * @return this builder
+     */
+    public Builder maxDuplicateComments(int maxDuplicateComments) {
+      if (maxDuplicateComments < -1 || maxDuplicateComments == 0) {
+        throw new IllegalArgumentException(
+            "maxDuplicateComments must be -1 (unlimited) or a positive integer, got: "
+                + maxDuplicateComments);
+      }
+      this.maxDuplicateComments = maxDuplicateComments;
+      return this;
+    }
+
+    /**
      * Sets the maximum number of exception reports that can be buffered in the internal queue
      * awaiting the background worker thread.
      *
@@ -444,8 +469,10 @@ public final class Observarium {
         log.warn("No PostingService configured — captured exceptions will be silently ignored");
       }
 
-      var config = new ObservariumConfig(scrubLevel, postingServices.size());
-      var processor = new ExceptionProcessor(fingerprinter, scrubber, postingServices, listener);
+      var config = new ObservariumConfig(scrubLevel, postingServices.size(), maxDuplicateComments);
+      var processor =
+          new ExceptionProcessor(
+              fingerprinter, scrubber, postingServices, listener, maxDuplicateComments);
 
       var queue = new ArrayBlockingQueue<Runnable>(queueCapacity);
       var executor =

--- a/observarium-core/src/main/java/io/hephaistos/observarium/ObservariumConfig.java
+++ b/observarium-core/src/main/java/io/hephaistos/observarium/ObservariumConfig.java
@@ -19,5 +19,20 @@ import io.hephaistos.observarium.scrub.ScrubLevel;
  * @param postingServiceCount the number of {@link io.hephaistos.observarium.posting.PostingService}
  *     instances registered at build time; zero indicates that captured exceptions will not be
  *     forwarded anywhere
+ * @param maxDuplicateComments the maximum number of duplicate comments Observarium will post on a
+ *     single issue before stopping; {@link #UNLIMITED_COMMENTS} means no limit is applied
  */
-public record ObservariumConfig(ScrubLevel scrubLevel, int postingServiceCount) {}
+public record ObservariumConfig(
+    ScrubLevel scrubLevel, int postingServiceCount, int maxDuplicateComments) {
+
+  /** Default value: 5 comments allowed per issue before the limit notice is posted. */
+  public static final int DEFAULT_MAX_DUPLICATE_COMMENTS = 5;
+
+  /** Sentinel value meaning unlimited comments (no cap). */
+  public static final int UNLIMITED_COMMENTS = -1;
+
+  /** Backward-compatible constructor that uses the default comment limit. */
+  public ObservariumConfig(ScrubLevel scrubLevel, int postingServiceCount) {
+    this(scrubLevel, postingServiceCount, DEFAULT_MAX_DUPLICATE_COMMENTS);
+  }
+}

--- a/observarium-core/src/main/java/io/hephaistos/observarium/ObservariumListener.java
+++ b/observarium-core/src/main/java/io/hephaistos/observarium/ObservariumListener.java
@@ -57,6 +57,19 @@ public interface ObservariumListener {
       String serviceName, boolean duplicate, boolean success, long durationNanos) {}
 
   /**
+   * Called when a duplicate comment is suppressed because the issue has already reached the
+   * configured comment limit.
+   *
+   * <p>This signals that the exception is still occurring but Observarium has stopped adding
+   * comments to avoid flooding the issue tracker. Monitor the {@code observarium.comments.dropped}
+   * metric for ongoing occurrence counts.
+   *
+   * @param serviceName the {@link io.hephaistos.observarium.posting.PostingService#name()} of the
+   *     service whose comment was dropped
+   */
+  default void onCommentDropped(String serviceName) {}
+
+  /**
    * Called once during {@link Observarium} construction to provide access to the current queue
    * depth.
    *

--- a/observarium-core/src/main/java/io/hephaistos/observarium/handler/ExceptionProcessor.java
+++ b/observarium-core/src/main/java/io/hephaistos/observarium/handler/ExceptionProcessor.java
@@ -1,9 +1,11 @@
 package io.hephaistos.observarium.handler;
 
+import io.hephaistos.observarium.ObservariumConfig;
 import io.hephaistos.observarium.ObservariumListener;
 import io.hephaistos.observarium.event.ExceptionEvent;
 import io.hephaistos.observarium.event.Severity;
 import io.hephaistos.observarium.fingerprint.ExceptionFingerprinter;
+import io.hephaistos.observarium.posting.DuplicateSearchResult;
 import io.hephaistos.observarium.posting.PostingResult;
 import io.hephaistos.observarium.posting.PostingService;
 import io.hephaistos.observarium.scrub.DataScrubber;
@@ -37,16 +39,33 @@ public class ExceptionProcessor {
   private final DataScrubber scrubber;
   private final List<PostingService> postingServices;
   private final ObservariumListener listener;
+  private final int maxDuplicateComments;
 
   public ExceptionProcessor(
       ExceptionFingerprinter fingerprinter,
       DataScrubber scrubber,
       List<PostingService> postingServices,
-      ObservariumListener listener) {
+      ObservariumListener listener,
+      int maxDuplicateComments) {
     this.fingerprinter = fingerprinter;
     this.scrubber = scrubber;
     this.postingServices = List.copyOf(postingServices);
     this.listener = listener;
+    this.maxDuplicateComments = maxDuplicateComments;
+  }
+
+  /** Backward-compatible constructor that uses the default comment limit. */
+  public ExceptionProcessor(
+      ExceptionFingerprinter fingerprinter,
+      DataScrubber scrubber,
+      List<PostingService> postingServices,
+      ObservariumListener listener) {
+    this(
+        fingerprinter,
+        scrubber,
+        postingServices,
+        listener,
+        ObservariumConfig.DEFAULT_MAX_DUPLICATE_COMMENTS);
   }
 
   /**
@@ -91,11 +110,7 @@ public class ExceptionProcessor {
         duplicate = duplicateResult.found();
         PostingResult result;
         if (duplicate) {
-          log.info(
-              "Duplicate found on {} (issue {}), adding comment",
-              service.name(),
-              duplicateResult.externalIssueId());
-          result = service.commentOnIssue(duplicateResult.externalIssueId(), event);
+          result = handleDuplicate(service, duplicateResult, event);
         } else {
           log.info("No duplicate on {}, creating new issue", service.name());
           result = service.createIssue(event);
@@ -112,6 +127,47 @@ public class ExceptionProcessor {
       }
     }
     return results;
+  }
+
+  private PostingResult handleDuplicate(
+      PostingService service, DuplicateSearchResult duplicateResult, ExceptionEvent event) {
+    int commentCount = duplicateResult.commentCount();
+    boolean limitEnabled = maxDuplicateComments != ObservariumConfig.UNLIMITED_COMMENTS;
+    boolean countKnown = commentCount != DuplicateSearchResult.COMMENT_COUNT_UNKNOWN;
+
+    if (limitEnabled && countKnown && commentCount > maxDuplicateComments) {
+      log.info(
+          "Comment limit reached on {} (issue {}, comments={}), dropping",
+          service.name(),
+          duplicateResult.externalIssueId(),
+          commentCount);
+      notifyCommentDropped(service.name());
+      return PostingResult.success(duplicateResult.externalIssueId(), duplicateResult.url());
+    }
+
+    if (limitEnabled && countKnown && commentCount == maxDuplicateComments) {
+      log.info(
+          "Posting comment limit notice on {} (issue {}, comments={})",
+          service.name(),
+          duplicateResult.externalIssueId(),
+          commentCount);
+      return service.postCommentLimitNotice(
+          duplicateResult.externalIssueId(), maxDuplicateComments);
+    }
+
+    log.info(
+        "Duplicate found on {} (issue {}), adding comment",
+        service.name(),
+        duplicateResult.externalIssueId());
+    return service.commentOnIssue(duplicateResult.externalIssueId(), event);
+  }
+
+  private void notifyCommentDropped(String serviceName) {
+    try {
+      listener.onCommentDropped(serviceName);
+    } catch (Exception ex) {
+      log.debug("Listener callback onCommentDropped failed", ex);
+    }
   }
 
   private void notifyPostingCompleted(

--- a/observarium-core/src/main/java/io/hephaistos/observarium/posting/DefaultIssueFormatter.java
+++ b/observarium-core/src/main/java/io/hephaistos/observarium/posting/DefaultIssueFormatter.java
@@ -17,7 +17,7 @@ public class DefaultIssueFormatter implements IssueFormatter {
 
   @Override
   public String fingerprintMarker(String fingerprint) {
-    return "<!-- observarium:fingerprint:" + fingerprint + " -->";
+    return "<!-- observarium:fingerprint:%s -->".formatted(fingerprint);
   }
 
   @Override
@@ -36,55 +36,76 @@ public class DefaultIssueFormatter implements IssueFormatter {
 
   @Override
   public String markdownBody(ExceptionEvent event) {
-    var body = new StringBuilder();
-    body.append(fingerprintMarker(event.fingerprint())).append("\n\n");
-    body.append("## Exception\n\n");
-    body.append("**Type:** `").append(event.exceptionClass()).append("`\n\n");
-    body.append("**Message:** ")
-        .append(event.message() != null ? event.message() : "N/A")
-        .append("\n\n");
-    body.append("**Severity:** ").append(event.severity()).append("\n\n");
-    body.append("**Timestamp:** ").append(event.timestamp()).append("\n\n");
-    body.append("**Thread:** ").append(event.threadName()).append("\n\n");
+    var message = event.message() != null ? event.message() : "N/A";
 
+    var extras = new StringBuilder();
     if (event.traceId() != null) {
-      body.append("**Trace ID:** `").append(event.traceId()).append("`\n\n");
+      extras.append("**Trace ID:** `%s`\n\n".formatted(event.traceId()));
     }
     if (event.spanId() != null) {
-      body.append("**Span ID:** `").append(event.spanId()).append("`\n\n");
+      extras.append("**Span ID:** `%s`\n\n".formatted(event.spanId()));
     }
 
+    var tags = "";
     if (!event.tags().isEmpty()) {
-      body.append("## Tags\n\n");
+      var tagSection = new StringBuilder("## Tags\n\n");
       event
           .tags()
-          .forEach(
-              (key, value) ->
-                  body.append("- **").append(key).append(":** ").append(value).append("\n"));
-      body.append("\n");
+          .forEach((key, value) -> tagSection.append("- **%s:** %s\n".formatted(key, value)));
+      tagSection.append("\n");
+      tags = tagSection.toString();
     }
 
-    body.append("## Stack Trace\n\n```\n");
-    body.append(event.rawStackTrace());
-    body.append("\n```\n\n");
+    return """
+        %s
 
-    body.append("**Fingerprint:** `").append(event.fingerprint()).append("`\n");
-    return body.toString();
+        ## Exception
+
+        **Type:** `%s`
+
+        **Message:** %s
+
+        **Severity:** %s
+
+        **Timestamp:** %s
+
+        **Thread:** %s
+
+        %s%s## Stack Trace
+
+        ```
+        %s
+        ```
+
+        **Fingerprint:** `%s`
+        """
+        .formatted(
+            fingerprintMarker(event.fingerprint()),
+            event.exceptionClass(),
+            message,
+            event.severity(),
+            event.timestamp(),
+            event.threadName(),
+            extras,
+            tags,
+            event.rawStackTrace(),
+            event.fingerprint());
   }
 
   @Override
   public String markdownComment(ExceptionEvent event) {
-    var comment = new StringBuilder();
-    comment.append("## Occurred Again\n\n");
-    comment.append("**Timestamp:** ").append(event.timestamp()).append("\n\n");
-    comment.append("**Thread:** ").append(event.threadName()).append("\n\n");
-    if (event.traceId() != null) {
-      comment.append("**Trace ID:** `").append(event.traceId()).append("`\n\n");
-    }
-    if (!event.tags().isEmpty()) {
-      comment.append("**Tags:** ").append(event.tags()).append("\n\n");
-    }
-    comment.append("**Severity:** ").append(event.severity()).append("\n");
-    return comment.toString();
+    var traceId =
+        event.traceId() != null ? "**Trace ID:** `%s`\n\n".formatted(event.traceId()) : "";
+    var tags = !event.tags().isEmpty() ? "**Tags:** %s\n\n".formatted(event.tags()) : "";
+    return """
+        ## Occurred Again
+
+        **Timestamp:** %s
+
+        **Thread:** %s
+
+        %s%s**Severity:** %s
+        """
+        .formatted(event.timestamp(), event.threadName(), traceId, tags, event.severity());
   }
 }

--- a/observarium-core/src/main/java/io/hephaistos/observarium/posting/DuplicateSearchResult.java
+++ b/observarium-core/src/main/java/io/hephaistos/observarium/posting/DuplicateSearchResult.java
@@ -8,19 +8,42 @@ package io.hephaistos.observarium.posting;
  *
  * <ul>
  *   <li>{@link #notFound()} — when no matching issue exists in the tracker.
- *   <li>{@link #found(String, String)} — when a matching issue was located.
+ *   <li>{@link #found(String, String)} — when a matching issue was located but the comment count is
+ *       unknown.
+ *   <li>{@link #found(String, String, int)} — when a matching issue was located and the service
+ *       provides the current comment count.
  * </ul>
  *
  * <p>Nullability contract: when {@link #found()} is {@code false}, both {@link #externalIssueId()}
  * and {@link #url()} are {@code null}.
+ *
+ * @param found {@code true} if a matching issue was located
+ * @param externalIssueId the tracker-specific issue identifier, or {@code null} when not found
+ * @param url the web URL of the issue, or {@code null} when not found
+ * @param commentCount the number of comments on the issue, or {@link #COMMENT_COUNT_UNKNOWN} when
+ *     the service did not provide a count
  */
-public record DuplicateSearchResult(boolean found, String externalIssueId, String url) {
+public record DuplicateSearchResult(
+    boolean found, String externalIssueId, String url, int commentCount) {
+
+  /** Sentinel indicating the comment count is unknown (service did not provide it). */
+  public static final int COMMENT_COUNT_UNKNOWN = -1;
 
   public static DuplicateSearchResult notFound() {
-    return new DuplicateSearchResult(false, null, null);
+    return new DuplicateSearchResult(false, null, null, COMMENT_COUNT_UNKNOWN);
   }
 
+  /** Creates a result when a matching issue was located but the comment count is unknown. */
   public static DuplicateSearchResult found(String externalIssueId, String url) {
-    return new DuplicateSearchResult(true, externalIssueId, url);
+    return new DuplicateSearchResult(true, externalIssueId, url, COMMENT_COUNT_UNKNOWN);
+  }
+
+  /** Creates a result when a matching issue was located with a known comment count. */
+  public static DuplicateSearchResult found(String externalIssueId, String url, int commentCount) {
+    if (commentCount < COMMENT_COUNT_UNKNOWN) {
+      throw new IllegalArgumentException(
+          "commentCount must be >= -1 (COMMENT_COUNT_UNKNOWN), got: " + commentCount);
+    }
+    return new DuplicateSearchResult(true, externalIssueId, url, commentCount);
   }
 }

--- a/observarium-core/src/main/java/io/hephaistos/observarium/posting/IssueFormatter.java
+++ b/observarium-core/src/main/java/io/hephaistos/observarium/posting/IssueFormatter.java
@@ -60,4 +60,23 @@ public interface IssueFormatter {
    * @return a non-null string ready to be submitted as a tracker comment
    */
   String markdownComment(ExceptionEvent event);
+
+  /**
+   * Generates a final notice comment indicating that the configured comment limit has been reached
+   * and Observarium will no longer add comments to this issue.
+   *
+   * @param commentLimit the maximum number of duplicate comments that were allowed
+   * @return a non-null string ready to be submitted as a tracker comment
+   */
+  default String markdownCommentLimitNotice(int commentLimit) {
+    return """
+        ## Comment Limit Reached
+
+        This exception has recurred more than **%d** times. \
+        Observarium will no longer add comments to this issue.
+
+        The exception is still being tracked — check your application metrics \
+        (`observarium.comments.dropped`) for ongoing occurrence counts."""
+        .formatted(commentLimit);
+  }
 }

--- a/observarium-core/src/main/java/io/hephaistos/observarium/posting/PostingService.java
+++ b/observarium-core/src/main/java/io/hephaistos/observarium/posting/PostingService.java
@@ -74,6 +74,23 @@ public interface PostingService {
   PostingResult commentOnIssue(String externalIssueId, ExceptionEvent event);
 
   /**
+   * Posts a final notice comment on an existing issue indicating that the configured comment limit
+   * has been reached and Observarium will stop commenting.
+   *
+   * <p>The default implementation returns a failure result. Posting service implementations that
+   * support commenting should override this to post the notice using {@link
+   * IssueFormatter#markdownCommentLimitNotice(int)}.
+   *
+   * @param externalIssueId the tracker-specific issue identifier returned by {@link
+   *     DuplicateSearchResult#externalIssueId()}; never null
+   * @param commentLimit the configured maximum number of duplicate comments
+   * @return a {@link PostingResult} indicating success or failure; never null
+   */
+  default PostingResult postCommentLimitNotice(String externalIssueId, int commentLimit) {
+    return PostingResult.failure("Comment limit notice not supported by " + name());
+  }
+
+  /**
    * Derives a label from the event fingerprint for tagging issues in external trackers.
    *
    * <p>The label uses the first 12 characters of the fingerprint hash prefixed with {@code

--- a/observarium-core/src/test/java/io/hephaistos/observarium/ObservariumConfigTest.java
+++ b/observarium-core/src/test/java/io/hephaistos/observarium/ObservariumConfigTest.java
@@ -47,4 +47,23 @@ class ObservariumConfigTest {
     ObservariumConfig b = new ObservariumConfig(ScrubLevel.BASIC, 2);
     assertNotEquals(a, b);
   }
+
+  @Test
+  void constructor_threeArg_storesMaxDuplicateComments() {
+    ObservariumConfig config = new ObservariumConfig(ScrubLevel.BASIC, 1, 10);
+    assertEquals(10, config.maxDuplicateComments());
+  }
+
+  @Test
+  void constructor_twoArg_defaultsToFiveMaxDuplicateComments() {
+    ObservariumConfig config = new ObservariumConfig(ScrubLevel.BASIC, 1);
+    assertEquals(5, config.maxDuplicateComments());
+  }
+
+  @Test
+  void twoConfigsWithDifferentMaxDuplicateComments_areNotEqual() {
+    ObservariumConfig a = new ObservariumConfig(ScrubLevel.BASIC, 1, 5);
+    ObservariumConfig b = new ObservariumConfig(ScrubLevel.BASIC, 1, 10);
+    assertNotEquals(a, b);
+  }
 }

--- a/observarium-core/src/test/java/io/hephaistos/observarium/ObservariumListenerTest.java
+++ b/observarium-core/src/test/java/io/hephaistos/observarium/ObservariumListenerTest.java
@@ -143,6 +143,38 @@ class ObservariumListenerTest {
     assertThat(results.get(0).success()).isTrue();
   }
 
+  @Test
+  void listener_receivesOnCommentDropped_whenLimitExceeded() throws Exception {
+    RecordingListener listener = new RecordingListener();
+    var completedLatch = new CountDownLatch(1);
+    observarium =
+        Observarium.builder()
+            .maxDuplicateComments(5)
+            .listener(
+                new ObservariumListener() {
+                  @Override
+                  public void onCommentDropped(String serviceName) {
+                    listener.onCommentDropped(serviceName);
+                  }
+
+                  @Override
+                  public void onPostingCompleted(
+                      String serviceName, boolean duplicate, boolean success, long durationNanos) {
+                    listener.onPostingCompleted(serviceName, duplicate, success, durationNanos);
+                    completedLatch.countDown();
+                  }
+                })
+            .addPostingService(commentLimitExceededService("tracker"))
+            .build();
+
+    observarium.captureException(new RuntimeException("test")).get(5, TimeUnit.SECONDS);
+    assertThat(completedLatch.await(5, TimeUnit.SECONDS))
+        .as("onPostingCompleted should be called")
+        .isTrue();
+
+    assertThat(listener.commentDroppedServiceNames).containsExactly("tracker");
+  }
+
   // ---------------------------------------------------------------------------
   // Recording listener
   // ---------------------------------------------------------------------------
@@ -152,6 +184,7 @@ class ObservariumListenerTest {
     final List<Severity> capturedSeverities = new CopyOnWriteArrayList<>();
     final AtomicInteger droppedCount = new AtomicInteger();
     final List<PostingCompletion> postingCompletions = new CopyOnWriteArrayList<>();
+    final List<String> commentDroppedServiceNames = new CopyOnWriteArrayList<>();
     volatile Supplier<Integer> queueSizeSupplier;
 
     @Override
@@ -168,6 +201,11 @@ class ObservariumListenerTest {
     public void onPostingCompleted(
         String serviceName, boolean duplicate, boolean success, long durationNanos) {
       postingCompletions.add(new PostingCompletion(serviceName, duplicate, success, durationNanos));
+    }
+
+    @Override
+    public void onCommentDropped(String serviceName) {
+      commentDroppedServiceNames.add(serviceName);
     }
 
     @Override
@@ -223,6 +261,31 @@ class ObservariumListenerTest {
           Thread.currentThread().interrupt();
         }
         return DuplicateSearchResult.notFound();
+      }
+
+      @Override
+      public PostingResult createIssue(ExceptionEvent event) {
+        return PostingResult.success("ISSUE-1", "https://tracker/ISSUE-1");
+      }
+
+      @Override
+      public PostingResult commentOnIssue(String externalIssueId, ExceptionEvent event) {
+        return PostingResult.success(externalIssueId, "https://tracker/" + externalIssueId);
+      }
+    };
+  }
+
+  private static PostingService commentLimitExceededService(String name) {
+    return new PostingService() {
+      @Override
+      public String name() {
+        return name;
+      }
+
+      @Override
+      public DuplicateSearchResult findDuplicate(ExceptionEvent event) {
+        // Return a duplicate with a comment count that exceeds the configured limit of 5
+        return DuplicateSearchResult.found("ISSUE-1", "https://tracker/ISSUE-1", 10);
       }
 
       @Override

--- a/observarium-core/src/test/java/io/hephaistos/observarium/ObservariumTest.java
+++ b/observarium-core/src/test/java/io/hephaistos/observarium/ObservariumTest.java
@@ -355,6 +355,49 @@ class ObservariumTest {
   }
 
   // -----------------------------------------------------------------------
+  // maxDuplicateComments builder option
+  // -----------------------------------------------------------------------
+
+  @Test
+  void builder_maxDuplicateComments_storesInConfig() {
+    Observarium obs = Observarium.builder().maxDuplicateComments(10).build();
+    try {
+      assertEquals(10, obs.config().maxDuplicateComments());
+    } finally {
+      obs.shutdown();
+    }
+  }
+
+  @Test
+  void builder_defaultMaxDuplicateComments_isFive() {
+    Observarium obs = Observarium.builder().build();
+    try {
+      assertEquals(5, obs.config().maxDuplicateComments());
+    } finally {
+      obs.shutdown();
+    }
+  }
+
+  @Test
+  void builder_maxDuplicateComments_rejectsZero() {
+    Observarium.Builder builder = Observarium.builder();
+    assertThrows(IllegalArgumentException.class, () -> builder.maxDuplicateComments(0));
+  }
+
+  @Test
+  void builder_maxDuplicateComments_rejectsNegativeTwo() {
+    Observarium.Builder builder = Observarium.builder();
+    assertThrows(IllegalArgumentException.class, () -> builder.maxDuplicateComments(-2));
+  }
+
+  @Test
+  void builder_maxDuplicateComments_acceptsMinusOne() {
+    // -1 is the sentinel value meaning unlimited comments.
+    Observarium.Builder builder = Observarium.builder();
+    assertDoesNotThrow(() -> builder.maxDuplicateComments(-1));
+  }
+
+  // -----------------------------------------------------------------------
   // addScrubPattern builder option
   // -----------------------------------------------------------------------
 

--- a/observarium-core/src/test/java/io/hephaistos/observarium/handler/ExceptionProcessorTest.java
+++ b/observarium-core/src/test/java/io/hephaistos/observarium/handler/ExceptionProcessorTest.java
@@ -2,6 +2,7 @@ package io.hephaistos.observarium.handler;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.hephaistos.observarium.ObservariumConfig;
 import io.hephaistos.observarium.ObservariumListener;
 import io.hephaistos.observarium.event.ExceptionEvent;
 import io.hephaistos.observarium.event.Severity;
@@ -44,6 +45,8 @@ class ExceptionProcessorTest {
     final List<ExceptionEvent> createIssueCalls = new ArrayList<>();
     final List<String> commentIssueIds = new ArrayList<>();
     final List<ExceptionEvent> commentEventCalls = new ArrayList<>();
+    final List<String> limitNoticeIssueIds = new ArrayList<>();
+    final List<Integer> limitNoticeLimits = new ArrayList<>();
 
     RecordingPostingService(String name, DuplicateSearchResult duplicateResult) {
       this.serviceName = name;
@@ -70,6 +73,13 @@ class ExceptionProcessorTest {
     public PostingResult commentOnIssue(String externalIssueId, ExceptionEvent event) {
       commentIssueIds.add(externalIssueId);
       commentEventCalls.add(event);
+      return PostingResult.success(externalIssueId, "https://tracker/" + externalIssueId);
+    }
+
+    @Override
+    public PostingResult postCommentLimitNotice(String externalIssueId, int commentLimit) {
+      limitNoticeIssueIds.add(externalIssueId);
+      limitNoticeLimits.add(commentLimit);
       return PostingResult.success(externalIssueId, "https://tracker/" + externalIssueId);
     }
   }
@@ -181,9 +191,25 @@ class ExceptionProcessorTest {
 
   private static final ObservariumListener NOOP_LISTENER = new ObservariumListener() {};
 
+  /** Records every {@link ObservariumListener#onCommentDropped} call. */
+  private static class RecordingListener implements ObservariumListener {
+    final List<String> droppedServiceNames = new ArrayList<>();
+
+    @Override
+    public void onCommentDropped(String serviceName) {
+      droppedServiceNames.add(serviceName);
+    }
+  }
+
   private static ExceptionProcessor processor(List<PostingService> services) {
     return new ExceptionProcessor(
         FIXED_FINGERPRINTER, PASSTHROUGH_SCRUBBER, services, NOOP_LISTENER);
+  }
+
+  private static ExceptionProcessor processor(
+      List<PostingService> services, ObservariumListener listener, int maxDuplicateComments) {
+    return new ExceptionProcessor(
+        FIXED_FINGERPRINTER, PASSTHROUGH_SCRUBBER, services, listener, maxDuplicateComments);
   }
 
   /** Calls process with pre-captured trace context (as Observarium now does eagerly). */
@@ -480,5 +506,120 @@ class ExceptionProcessorTest {
     assertTrue(
         results.get(0).errorMessage().contains("comment-fail"),
         "Failure message must include the service name for diagnostics");
+  }
+
+  // -----------------------------------------------------------------------
+  // Tests: comment limit
+  // -----------------------------------------------------------------------
+
+  @Test
+  void duplicate_belowLimit_callsCommentOnIssue() {
+    String issueId = "ISSUE-10";
+    RecordingPostingService service =
+        new RecordingPostingService(
+            "svc", DuplicateSearchResult.found(issueId, "https://tracker/" + issueId, 2));
+
+    ExceptionProcessor proc = processor(List.of(service), NOOP_LISTENER, 5);
+    process(proc, new RuntimeException("below limit"), Severity.ERROR, Map.of());
+
+    assertEquals(1, service.commentIssueIds.size(), "commentOnIssue must be called once");
+    assertEquals(
+        0, service.limitNoticeIssueIds.size(), "postCommentLimitNotice must not be called");
+  }
+
+  @Test
+  void duplicate_atLimit_callsPostCommentLimitNotice() {
+    String issueId = "ISSUE-20";
+    RecordingPostingService service =
+        new RecordingPostingService(
+            "svc", DuplicateSearchResult.found(issueId, "https://tracker/" + issueId, 5));
+
+    ExceptionProcessor proc = processor(List.of(service), NOOP_LISTENER, 5);
+    process(proc, new RuntimeException("at limit"), Severity.ERROR, Map.of());
+
+    assertEquals(
+        1, service.limitNoticeIssueIds.size(), "postCommentLimitNotice must be called once");
+    assertEquals(
+        issueId,
+        service.limitNoticeIssueIds.get(0),
+        "postCommentLimitNotice must receive the correct issue id");
+    assertEquals(
+        5,
+        service.limitNoticeLimits.get(0),
+        "postCommentLimitNotice must receive the configured limit");
+    assertEquals(0, service.commentIssueIds.size(), "commentOnIssue must not be called");
+  }
+
+  @Test
+  void duplicate_overLimit_dropsComment() {
+    String issueId = "ISSUE-30";
+    RecordingPostingService service =
+        new RecordingPostingService(
+            "svc", DuplicateSearchResult.found(issueId, "https://tracker/" + issueId, 6));
+
+    ExceptionProcessor proc = processor(List.of(service), NOOP_LISTENER, 5);
+    List<PostingResult> results =
+        process(proc, new RuntimeException("over limit"), Severity.ERROR, Map.of());
+
+    assertEquals(0, service.commentIssueIds.size(), "commentOnIssue must not be called");
+    assertEquals(
+        0, service.limitNoticeIssueIds.size(), "postCommentLimitNotice must not be called");
+    assertEquals(1, results.size());
+    assertTrue(results.get(0).success(), "Dropped comment must still yield a success result");
+  }
+
+  @Test
+  void duplicate_overLimit_notifiesListener() {
+    String issueId = "ISSUE-40";
+    RecordingPostingService service =
+        new RecordingPostingService(
+            "svc", DuplicateSearchResult.found(issueId, "https://tracker/" + issueId, 10));
+    RecordingListener listener = new RecordingListener();
+
+    ExceptionProcessor proc = processor(List.of(service), listener, 5);
+    process(proc, new RuntimeException("over limit notify"), Severity.ERROR, Map.of());
+
+    assertEquals(1, listener.droppedServiceNames.size(), "onCommentDropped must be called once");
+    assertEquals(
+        "svc",
+        listener.droppedServiceNames.get(0),
+        "onCommentDropped must receive the correct service name");
+  }
+
+  @Test
+  void duplicate_unknownCount_fallsOpenToComment() {
+    // DuplicateSearchResult.found(id, url) — 2-arg — sets commentCount to COMMENT_COUNT_UNKNOWN.
+    // The processor must treat an unknown count as fail-open and call commentOnIssue.
+    String issueId = "ISSUE-50";
+    RecordingPostingService service =
+        new RecordingPostingService(
+            "svc", DuplicateSearchResult.found(issueId, "https://tracker/" + issueId));
+
+    ExceptionProcessor proc = processor(List.of(service), NOOP_LISTENER, 5);
+    process(proc, new RuntimeException("unknown count"), Severity.ERROR, Map.of());
+
+    assertEquals(
+        1, service.commentIssueIds.size(), "commentOnIssue must be called when count is unknown");
+    assertEquals(
+        0, service.limitNoticeIssueIds.size(), "postCommentLimitNotice must not be called");
+  }
+
+  @Test
+  void duplicate_unlimitedConfig_alwaysComments() {
+    // When the limit is UNLIMITED_COMMENTS (-1) the cap is disabled; commentOnIssue must always
+    // be called regardless of how high the comment count is.
+    String issueId = "ISSUE-60";
+    RecordingPostingService service =
+        new RecordingPostingService(
+            "svc", DuplicateSearchResult.found(issueId, "https://tracker/" + issueId, 100));
+
+    ExceptionProcessor proc =
+        processor(List.of(service), NOOP_LISTENER, ObservariumConfig.UNLIMITED_COMMENTS);
+    process(proc, new RuntimeException("unlimited"), Severity.ERROR, Map.of());
+
+    assertEquals(
+        1, service.commentIssueIds.size(), "commentOnIssue must be called when limit is UNLIMITED");
+    assertEquals(
+        0, service.limitNoticeIssueIds.size(), "postCommentLimitNotice must not be called");
   }
 }

--- a/observarium-core/src/test/java/io/hephaistos/observarium/posting/IssueFormatterTest.java
+++ b/observarium-core/src/test/java/io/hephaistos/observarium/posting/IssueFormatterTest.java
@@ -237,4 +237,30 @@ class IssueFormatterTest {
         formatter.markdownComment(event).startsWith("## Occurred Again"),
         "Comment must start with the 'Occurred Again' header");
   }
+
+  // -----------------------------------------------------------------------
+  // markdownCommentLimitNotice()
+  // -----------------------------------------------------------------------
+
+  @Test
+  void markdownCommentLimitNotice_containsLimitNumber() {
+    String notice = formatter.markdownCommentLimitNotice(5);
+    assertTrue(notice.contains("5"), "Limit notice must contain the configured limit number");
+  }
+
+  @Test
+  void markdownCommentLimitNotice_containsMetricHint() {
+    String notice = formatter.markdownCommentLimitNotice(5);
+    assertTrue(
+        notice.contains("observarium.comments.dropped"),
+        "Limit notice must reference the observarium.comments.dropped metric");
+  }
+
+  @Test
+  void markdownCommentLimitNotice_containsCommentLimitHeader() {
+    String notice = formatter.markdownCommentLimitNotice(5);
+    assertTrue(
+        notice.contains("Comment Limit Reached"),
+        "Limit notice must contain the 'Comment Limit Reached' header");
+  }
 }

--- a/observarium-core/src/test/java/io/hephaistos/observarium/posting/PostingServiceTest.java
+++ b/observarium-core/src/test/java/io/hephaistos/observarium/posting/PostingServiceTest.java
@@ -61,4 +61,57 @@ class PostingServiceTest {
   void fingerprintLabel_throwsOnNullFingerprint() {
     assertThrows(NullPointerException.class, () -> service.fingerprintLabel(null));
   }
+
+  @Test
+  void postCommentLimitNotice_defaultReturnsFailure() {
+    PostingResult result = service.postCommentLimitNotice("ISSUE-1", 5);
+    assertFalse(result.success(), "Default postCommentLimitNotice must return a failure result");
+    assertTrue(
+        result.errorMessage().contains("test"), "Failure message must reference the service name");
+  }
+
+  // -----------------------------------------------------------------------
+  // DuplicateSearchResult factory methods
+  // -----------------------------------------------------------------------
+
+  @Test
+  void notFound_returnsCommentCountUnknown() {
+    DuplicateSearchResult result = DuplicateSearchResult.notFound();
+    assertFalse(result.found());
+    assertEquals(DuplicateSearchResult.COMMENT_COUNT_UNKNOWN, result.commentCount());
+  }
+
+  @Test
+  void found_twoArg_returnsCommentCountUnknown() {
+    DuplicateSearchResult result = DuplicateSearchResult.found("ID-1", "https://t/1");
+    assertTrue(result.found());
+    assertEquals(DuplicateSearchResult.COMMENT_COUNT_UNKNOWN, result.commentCount());
+  }
+
+  @Test
+  void found_threeArg_storesCommentCount() {
+    DuplicateSearchResult result = DuplicateSearchResult.found("ID-1", "https://t/1", 7);
+    assertEquals(7, result.commentCount());
+  }
+
+  @Test
+  void found_threeArg_acceptsZero() {
+    DuplicateSearchResult result = DuplicateSearchResult.found("ID-1", "https://t/1", 0);
+    assertEquals(0, result.commentCount());
+  }
+
+  @Test
+  void found_threeArg_acceptsMinusOne() {
+    DuplicateSearchResult result =
+        DuplicateSearchResult.found(
+            "ID-1", "https://t/1", DuplicateSearchResult.COMMENT_COUNT_UNKNOWN);
+    assertEquals(DuplicateSearchResult.COMMENT_COUNT_UNKNOWN, result.commentCount());
+  }
+
+  @Test
+  void found_threeArg_rejectsNegativeBelowMinusOne() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DuplicateSearchResult.found("ID-1", "https://t/1", -2));
+  }
 }

--- a/observarium-email/src/main/java/io/hephaistos/observarium/email/EmailPostingService.java
+++ b/observarium-email/src/main/java/io/hephaistos/observarium/email/EmailPostingService.java
@@ -143,38 +143,48 @@ public class EmailPostingService implements PostingService {
    * written out explicitly so the message is self-contained.
    */
   private String buildPlainTextBody(ExceptionEvent event) {
-    var sb = new StringBuilder();
+    var message = event.message() != null ? event.message() : "(no message)";
 
-    sb.append("EXCEPTION NOTIFICATION\n");
-    sb.append("======================\n\n");
-
-    sb.append("Type:      ").append(event.exceptionClass()).append("\n");
-    sb.append("Message:   ")
-        .append(event.message() != null ? event.message() : "(no message)")
-        .append("\n");
-    sb.append("Severity:  ").append(event.severity()).append("\n");
-    sb.append("Timestamp: ").append(event.timestamp()).append("\n");
-    sb.append("Thread:    ").append(event.threadName()).append("\n");
-
+    var tracing = new StringBuilder();
     if (event.traceId() != null) {
-      sb.append("Trace ID:  ").append(event.traceId()).append("\n");
+      tracing.append("Trace ID:  %s\n".formatted(event.traceId()));
     }
     if (event.spanId() != null) {
-      sb.append("Span ID:   ").append(event.spanId()).append("\n");
+      tracing.append("Span ID:   %s\n".formatted(event.spanId()));
     }
 
+    var tags = "";
     if (!event.tags().isEmpty()) {
-      sb.append("\nTAGS\n");
-      sb.append("----\n");
-      event.tags().forEach((k, v) -> sb.append(k).append(": ").append(v).append("\n"));
+      var tagSection = new StringBuilder("\nTAGS\n----\n");
+      event.tags().forEach((k, v) -> tagSection.append("%s: %s\n".formatted(k, v)));
+      tags = tagSection.toString();
     }
 
-    sb.append("\nSTACK TRACE\n");
-    sb.append("-----------\n");
-    sb.append(event.rawStackTrace()).append("\n");
+    return """
+        EXCEPTION NOTIFICATION
+        ======================
 
-    sb.append("\nFingerprint: ").append(event.fingerprint()).append("\n");
+        Type:      %s
+        Message:   %s
+        Severity:  %s
+        Timestamp: %s
+        Thread:    %s
+        %s%s
+        STACK TRACE
+        -----------
+        %s
 
-    return sb.toString();
+        Fingerprint: %s
+        """
+        .formatted(
+            event.exceptionClass(),
+            message,
+            event.severity(),
+            event.timestamp(),
+            event.threadName(),
+            tracing,
+            tags,
+            event.rawStackTrace(),
+            event.fingerprint());
   }
 }

--- a/observarium-github/src/main/java/io/hephaistos/observarium/github/GitHubPostingService.java
+++ b/observarium-github/src/main/java/io/hephaistos/observarium/github/GitHubPostingService.java
@@ -109,9 +109,13 @@ public class GitHubPostingService implements PostingService, AutoCloseable {
       JsonObject issue = issues.get(0).getAsJsonObject();
       String issueNumber = String.valueOf(issue.get("number").getAsInt());
       String htmlUrl = issue.get("html_url").getAsString();
+      int commentCount =
+          issue.has("comments")
+              ? issue.get("comments").getAsInt()
+              : DuplicateSearchResult.COMMENT_COUNT_UNKNOWN;
 
       log.debug("Found duplicate issue. number={} url={}", issueNumber, htmlUrl);
-      return DuplicateSearchResult.found(issueNumber, htmlUrl);
+      return DuplicateSearchResult.found(issueNumber, htmlUrl, commentCount);
 
     } catch (IOException | InterruptedException e) {
       log.error(
@@ -184,6 +188,39 @@ public class GitHubPostingService implements PostingService, AutoCloseable {
   @Override
   public PostingResult commentOnIssue(String externalIssueId, ExceptionEvent event) {
     requireNonNull(externalIssueId, "externalIssueId must not be null");
+    log.debug(
+        "Adding comment to GitHub issue. number={} fingerprint={}",
+        externalIssueId,
+        event.fingerprint());
+    return postComment(externalIssueId, formatter.markdownComment(event));
+  }
+
+  /**
+   * Posts a final notice comment on an existing GitHub issue indicating that the configured comment
+   * limit has been reached and Observarium will stop commenting.
+   *
+   * @param externalIssueId the string issue number returned by a previous call to {@link
+   *     #createIssue} or {@link #findDuplicate}
+   * @param commentLimit the configured maximum number of duplicate comments
+   */
+  @Override
+  public PostingResult postCommentLimitNotice(String externalIssueId, int commentLimit) {
+    requireNonNull(externalIssueId, "externalIssueId must not be null");
+    log.debug(
+        "Posting comment-limit notice to GitHub issue. number={} limit={}",
+        externalIssueId,
+        commentLimit);
+    return postComment(externalIssueId, formatter.markdownCommentLimitNotice(commentLimit));
+  }
+
+  /**
+   * Builds and sends a POST request to the GitHub comments endpoint for the given issue, using
+   * {@code commentBody} as the comment text.
+   *
+   * <p>Shared by {@link #commentOnIssue} and {@link #postCommentLimitNotice} to avoid duplication
+   * of the HTTP dispatch and error-handling logic.
+   */
+  private PostingResult postComment(String externalIssueId, String commentBody) {
     String url =
         config.baseUrl()
             + "/repos/"
@@ -195,12 +232,7 @@ public class GitHubPostingService implements PostingService, AutoCloseable {
             + "/comments";
 
     JsonObject requestBody = new JsonObject();
-    requestBody.addProperty("body", formatter.markdownComment(event));
-
-    log.debug(
-        "Adding comment to GitHub issue. number={} fingerprint={}",
-        externalIssueId,
-        event.fingerprint());
+    requestBody.addProperty("body", commentBody);
 
     try {
       HttpRequest request = buildPostRequest(url, gson.toJson(requestBody));
@@ -227,11 +259,7 @@ public class GitHubPostingService implements PostingService, AutoCloseable {
       return PostingResult.success(externalIssueId, commentUrl);
 
     } catch (IOException | InterruptedException e) {
-      log.error(
-          "Failed to comment on GitHub issue. number={} fingerprint={}",
-          externalIssueId,
-          event.fingerprint(),
-          e);
+      log.error("Failed to comment on GitHub issue. number={}", externalIssueId, e);
       if (e instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }

--- a/observarium-github/src/test/java/io/hephaistos/observarium/github/GitHubPostingServiceTest.java
+++ b/observarium-github/src/test/java/io/hephaistos/observarium/github/GitHubPostingServiceTest.java
@@ -190,6 +190,63 @@ class GitHubPostingServiceTest {
 
   @Test
   @SuppressWarnings("unchecked")
+  void findDuplicate_returnsKnownCommentCount_whenIssueHasCommentsField() throws Exception {
+    String listResponse =
+        """
+                [
+                  {
+                    "number": 42,
+                    "html_url": "https://github.com/owner/repo/issues/42",
+                    "comments": 7
+                  }
+                ]
+                """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(listResponse);
+    when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    GitHubPostingService service =
+        new GitHubPostingService(
+            GitHubConfig.of("tok", "owner", "repo"), mockHttpClient, new DefaultIssueFormatter());
+
+    DuplicateSearchResult result = service.findDuplicate(buildEvent("MyException", "oops"));
+
+    assertTrue(result.found());
+    assertEquals(7, result.commentCount());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void findDuplicate_returnsUnknownCommentCount_whenIssueHasNoCommentsField() throws Exception {
+    // GitHub response without the "comments" field
+    String listResponse =
+        """
+                [
+                  { "number": 42, "html_url": "https://github.com/owner/repo/issues/42" }
+                ]
+                """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(listResponse);
+    when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    GitHubPostingService service =
+        new GitHubPostingService(
+            GitHubConfig.of("tok", "owner", "repo"), mockHttpClient, new DefaultIssueFormatter());
+
+    DuplicateSearchResult result = service.findDuplicate(buildEvent("MyException", "oops"));
+
+    assertTrue(result.found());
+    assertEquals(DuplicateSearchResult.COMMENT_COUNT_UNKNOWN, result.commentCount());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
   void findDuplicate_returnsNotFound_whenNoIssuesWithLabel() throws Exception {
     String listResponse = "[]";
 
@@ -395,6 +452,77 @@ class GitHubPostingServiceTest {
             GitHubConfig.of("tok", "owner", "repo"), mockHttpClient, new DefaultIssueFormatter());
     ExceptionEvent event = buildEvent("MyException", "oops");
     assertThrows(NullPointerException.class, () -> service.commentOnIssue(null, event));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void postCommentLimitNotice_returnsSuccess_withCommentUrl() throws Exception {
+    String commentResponse =
+        """
+                {
+                  "id": 888,
+                  "html_url": "https://github.com/owner/repo/issues/7#issuecomment-888"
+                }
+                """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(201);
+    when(httpResponse.body()).thenReturn(commentResponse);
+    when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    GitHubPostingService service =
+        new GitHubPostingService(
+            GitHubConfig.of("tok", "owner", "repo"), mockHttpClient, new DefaultIssueFormatter());
+
+    PostingResult result = service.postCommentLimitNotice("7", 10);
+
+    assertTrue(result.success());
+    assertEquals("7", result.externalIssueId());
+    assertEquals("https://github.com/owner/repo/issues/7#issuecomment-888", result.url());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void postCommentLimitNotice_returnsFailure_whenGitHubReturns404() throws Exception {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(404);
+    when(httpResponse.body()).thenReturn("{\"message\":\"Not Found\"}");
+    when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    GitHubPostingService service =
+        new GitHubPostingService(
+            GitHubConfig.of("tok", "owner", "repo"), mockHttpClient, new DefaultIssueFormatter());
+
+    PostingResult result = service.postCommentLimitNotice("9999", 10);
+
+    assertFalse(result.success());
+    assertTrue(result.errorMessage().contains("404"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void postCommentLimitNotice_returnsFailure_onNetworkError() throws Exception {
+    when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenThrow(new IOException("connection reset"));
+
+    GitHubPostingService service =
+        new GitHubPostingService(
+            GitHubConfig.of("tok", "owner", "repo"), mockHttpClient, new DefaultIssueFormatter());
+
+    PostingResult result = service.postCommentLimitNotice("7", 10);
+
+    assertFalse(result.success());
+    assertTrue(result.errorMessage().contains("connection reset"));
+  }
+
+  @Test
+  void postCommentLimitNotice_throwsNullPointerException_whenExternalIssueIdIsNull() {
+    GitHubPostingService service =
+        new GitHubPostingService(
+            GitHubConfig.of("tok", "owner", "repo"), mockHttpClient, new DefaultIssueFormatter());
+    assertThrows(NullPointerException.class, () -> service.postCommentLimitNotice(null, 10));
   }
 
   @Test

--- a/observarium-github/src/test/java/io/hephaistos/observarium/github/GitHubPostingServiceWireMockTest.java
+++ b/observarium-github/src/test/java/io/hephaistos/observarium/github/GitHubPostingServiceWireMockTest.java
@@ -77,6 +77,23 @@ class GitHubPostingServiceWireMockTest {
   }
 
   @Test
+  void findDuplicate_returnsCommentCount_fromIssueObject(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        get(urlPathEqualTo("/repos/test-owner/test-repo/issues"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "[{\"number\":42,\"html_url\":\"https://github.com/test-owner/test-repo/issues/42\",\"comments\":3}]")));
+
+    DuplicateSearchResult result = buildService(wmInfo).findDuplicate(buildEvent());
+
+    assertTrue(result.found());
+    assertEquals(3, result.commentCount());
+  }
+
+  @Test
   void findDuplicate_returnsNotFound_onEmptyArray(WireMockRuntimeInfo wmInfo) {
     stubFor(
         get(urlPathEqualTo("/repos/test-owner/test-repo/issues"))
@@ -246,6 +263,62 @@ class GitHubPostingServiceWireMockTest {
             .willReturn(aResponse().withStatus(404).withBody("{\"message\":\"Not Found\"}")));
 
     PostingResult result = buildService(wmInfo).commentOnIssue("42", buildEvent());
+
+    assertFalse(result.success());
+    assertNotNull(result.errorMessage());
+    assertTrue(result.errorMessage().contains("404"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // postCommentLimitNotice tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void postCommentLimitNotice_sendsCorrectUrlAndBody(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        post(urlPathEqualTo("/repos/test-owner/test-repo/issues/42/comments"))
+            .willReturn(
+                aResponse()
+                    .withStatus(201)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"html_url\":\"https://github.com/test-owner/test-repo/issues/42#issuecomment-2\"}")));
+
+    buildService(wmInfo).postCommentLimitNotice("42", 5);
+
+    verify(
+        postRequestedFor(urlPathEqualTo("/repos/test-owner/test-repo/issues/42/comments"))
+            .withHeader("Authorization", equalTo("Bearer " + TOKEN))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withHeader("X-GitHub-Api-Version", equalTo("2022-11-28"))
+            .withRequestBody(matchingJsonPath("$.body")));
+  }
+
+  @Test
+  void postCommentLimitNotice_returnsSuccess_on201(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        post(urlPathEqualTo("/repos/test-owner/test-repo/issues/42/comments"))
+            .willReturn(
+                aResponse()
+                    .withStatus(201)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"html_url\":\"https://github.com/test-owner/test-repo/issues/42#issuecomment-2\"}")));
+
+    PostingResult result = buildService(wmInfo).postCommentLimitNotice("42", 5);
+
+    assertTrue(result.success());
+    assertEquals("42", result.externalIssueId());
+    assertEquals("https://github.com/test-owner/test-repo/issues/42#issuecomment-2", result.url());
+  }
+
+  @Test
+  void postCommentLimitNotice_returnsFailure_on404(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        post(urlPathEqualTo("/repos/test-owner/test-repo/issues/42/comments"))
+            .willReturn(aResponse().withStatus(404).withBody("{\"message\":\"Not Found\"}")));
+
+    PostingResult result = buildService(wmInfo).postCommentLimitNotice("42", 5);
 
     assertFalse(result.success());
     assertNotNull(result.errorMessage());

--- a/observarium-gitlab/src/main/java/io/hephaistos/observarium/gitlab/GitLabPostingService.java
+++ b/observarium-gitlab/src/main/java/io/hephaistos/observarium/gitlab/GitLabPostingService.java
@@ -116,7 +116,11 @@ public class GitLabPostingService implements PostingService, AutoCloseable {
       JsonObject first = issues.get(0).getAsJsonObject();
       String iid = String.valueOf(first.get("iid").getAsLong());
       String webUrl = first.get("web_url").getAsString();
-      return DuplicateSearchResult.found(iid, webUrl);
+      int commentCount =
+          first.has("user_notes_count")
+              ? first.get("user_notes_count").getAsInt()
+              : DuplicateSearchResult.COMMENT_COUNT_UNKNOWN;
+      return DuplicateSearchResult.found(iid, webUrl, commentCount);
 
     } catch (Exception e) {
       log.error("Failed to search for duplicate GitLab issue", e);
@@ -180,6 +184,24 @@ public class GitLabPostingService implements PostingService, AutoCloseable {
   @Override
   public PostingResult commentOnIssue(String externalIssueId, ExceptionEvent event) {
     requireNonNull(externalIssueId, "externalIssueId must not be null");
+    return postNote(externalIssueId, formatter.markdownComment(event));
+  }
+
+  /**
+   * Posts a comment-limit notice on an existing GitLab issue, informing that Observarium will stop
+   * commenting once the configured limit is reached.
+   */
+  @Override
+  public PostingResult postCommentLimitNotice(String externalIssueId, int commentLimit) {
+    requireNonNull(externalIssueId, "externalIssueId must not be null");
+    return postNote(externalIssueId, formatter.markdownCommentLimitNotice(commentLimit));
+  }
+
+  /**
+   * Posts a note (GitLab's term for a comment) with {@code noteBody} on the issue identified by
+   * {@code externalIssueId}.
+   */
+  private PostingResult postNote(String externalIssueId, String noteBody) {
     String url =
         config.baseUrl()
             + "/api/v4/projects/"
@@ -189,7 +211,7 @@ public class GitLabPostingService implements PostingService, AutoCloseable {
             + "/notes";
 
     JsonObject body = new JsonObject();
-    body.addProperty("body", formatter.markdownComment(event));
+    body.addProperty("body", noteBody);
 
     HttpRequest request =
         HttpRequest.newBuilder()

--- a/observarium-gitlab/src/test/java/io/hephaistos/observarium/gitlab/GitLabPostingServiceTest.java
+++ b/observarium-gitlab/src/test/java/io/hephaistos/observarium/gitlab/GitLabPostingServiceTest.java
@@ -456,6 +456,115 @@ class GitLabPostingServiceTest {
   }
 
   // -------------------------------------------------------------------------
+  // findDuplicate() — comment count
+  // -------------------------------------------------------------------------
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void findDuplicate_returnsKnownCommentCount_whenIssueHasUserNotesCountField() throws Exception {
+    String responseBody =
+        """
+                [
+                  {
+                    "iid": 5,
+                    "web_url": "https://gitlab.example.com/group/proj/-/issues/5",
+                    "user_notes_count": 7
+                  }
+                ]
+                """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseBody);
+    when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    GitLabPostingService service =
+        new GitLabPostingService(CONFIG, mockHttpClient, new Gson(), new DefaultIssueFormatter());
+    DuplicateSearchResult result = service.findDuplicate(buildEvent("SomeException", "boom"));
+
+    assertTrue(result.found());
+    assertEquals(7, result.commentCount());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void findDuplicate_returnsUnknownCommentCount_whenIssueHasNoUserNotesCountField()
+      throws Exception {
+    // GitLab response without the "user_notes_count" field
+    String responseBody =
+        """
+                [
+                  { "iid": 5, "web_url": "https://gitlab.example.com/group/proj/-/issues/5" }
+                ]
+                """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseBody);
+    when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    GitLabPostingService service =
+        new GitLabPostingService(CONFIG, mockHttpClient, new Gson(), new DefaultIssueFormatter());
+    DuplicateSearchResult result = service.findDuplicate(buildEvent("SomeException", "boom"));
+
+    assertTrue(result.found());
+    assertEquals(DuplicateSearchResult.COMMENT_COUNT_UNKNOWN, result.commentCount());
+  }
+
+  // -------------------------------------------------------------------------
+  // postCommentLimitNotice() — success paths
+  // -------------------------------------------------------------------------
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void postCommentLimitNotice_returnsSuccess_withIssueId() throws Exception {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(201);
+    when(httpResponse.body()).thenReturn("{\"id\": 999, \"body\": \"comment limit notice\"}");
+    when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    GitLabPostingService service =
+        new GitLabPostingService(CONFIG, mockHttpClient, new Gson(), new DefaultIssueFormatter());
+    PostingResult result = service.postCommentLimitNotice("5", 10);
+
+    assertTrue(result.success());
+    assertEquals("5", result.externalIssueId());
+    assertNull(result.url());
+  }
+
+  // -------------------------------------------------------------------------
+  // postCommentLimitNotice() — error paths
+  // -------------------------------------------------------------------------
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void postCommentLimitNotice_returnsFailure_whenGitLabReturns404() throws Exception {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(404);
+    when(httpResponse.body()).thenReturn("{\"message\":\"404 Issue Not Found\"}");
+    when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    GitLabPostingService service =
+        new GitLabPostingService(CONFIG, mockHttpClient, new Gson(), new DefaultIssueFormatter());
+    PostingResult result = service.postCommentLimitNotice("9999", 10);
+
+    assertFalse(result.success());
+    assertNotNull(result.errorMessage());
+    assertTrue(result.errorMessage().contains("404"));
+  }
+
+  @Test
+  void postCommentLimitNotice_throwsNullPointerException_whenExternalIssueIdIsNull() {
+    GitLabPostingService service =
+        new GitLabPostingService(CONFIG, mockHttpClient, new Gson(), new DefaultIssueFormatter());
+    assertThrows(NullPointerException.class, () -> service.postCommentLimitNotice(null, 10));
+  }
+
+  // -------------------------------------------------------------------------
   // URL encoding — namespace/path project IDs
   // -------------------------------------------------------------------------
 
@@ -520,6 +629,26 @@ class GitLabPostingServiceTest {
         new GitLabPostingService(
             NAMESPACE_CONFIG, mockHttpClient, new Gson(), new DefaultIssueFormatter());
     service.commentOnIssue("3", buildEvent("SomeException", "boom"));
+
+    verify(mockHttpClient)
+        .send(
+            argThat(req -> req.uri().toString().contains("mygroup%2Fmyproject")),
+            any(HttpResponse.BodyHandler.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void postCommentLimitNotice_urlEncodesNamespaceProjectId() throws Exception {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(201);
+    when(httpResponse.body()).thenReturn("{\"id\": 1}");
+    when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    GitLabPostingService service =
+        new GitLabPostingService(
+            NAMESPACE_CONFIG, mockHttpClient, new Gson(), new DefaultIssueFormatter());
+    service.postCommentLimitNotice("3", 10);
 
     verify(mockHttpClient)
         .send(
@@ -613,6 +742,13 @@ class GitLabPostingServiceTest {
   void commentOnIssue_returnsFailure_whenRealHttpClientCannotConnect() {
     GitLabPostingService service = new GitLabPostingService(CONFIG);
     PostingResult result = service.commentOnIssue("99", buildEvent("SomeException", "boom"));
+    assertFalse(result.success());
+  }
+
+  @Test
+  void postCommentLimitNotice_returnsFailure_whenRealHttpClientCannotConnect() {
+    GitLabPostingService service = new GitLabPostingService(CONFIG);
+    PostingResult result = service.postCommentLimitNotice("99", 10);
     assertFalse(result.success());
   }
 

--- a/observarium-gitlab/src/test/java/io/hephaistos/observarium/gitlab/GitLabPostingServiceWireMockTest.java
+++ b/observarium-gitlab/src/test/java/io/hephaistos/observarium/gitlab/GitLabPostingServiceWireMockTest.java
@@ -97,6 +97,23 @@ class GitLabPostingServiceWireMockTest {
   }
 
   @Test
+  void findDuplicate_returnsCommentCount_fromIssueObject(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        get(urlPathEqualTo("/api/v4/projects/42/issues"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "[{\"iid\":5,\"web_url\":\"https://gitlab.com/test-group/test-repo/-/issues/5\",\"user_notes_count\":3}]")));
+
+    DuplicateSearchResult result = buildService(wmInfo).findDuplicate(buildEvent());
+
+    assertTrue(result.found());
+    assertEquals(3, result.commentCount());
+  }
+
+  @Test
   void findDuplicate_returnsNotFound_onEmptyArray(WireMockRuntimeInfo wmInfo) {
     stubFor(
         get(urlPathEqualTo("/api/v4/projects/42/issues"))
@@ -245,6 +262,60 @@ class GitLabPostingServiceWireMockTest {
                 aResponse().withStatus(404).withBody("{\"message\":\"404 Issue Not Found\"}")));
 
     PostingResult result = buildService(wmInfo).commentOnIssue("5", buildEvent());
+
+    assertFalse(result.success());
+    assertNotNull(result.errorMessage());
+    assertTrue(result.errorMessage().contains("404"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // postCommentLimitNotice tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void postCommentLimitNotice_sendsPostToNotesEndpoint(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        post(urlPathEqualTo("/api/v4/projects/42/issues/5/notes"))
+            .willReturn(
+                aResponse()
+                    .withStatus(201)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"id\":202,\"body\":\"comment limit notice\"}")));
+
+    buildService(wmInfo).postCommentLimitNotice("5", 10);
+
+    verify(
+        postRequestedFor(urlPathEqualTo("/api/v4/projects/42/issues/5/notes"))
+            .withHeader("PRIVATE-TOKEN", equalTo(PRIVATE_TOKEN))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(matchingJsonPath("$.body")));
+  }
+
+  @Test
+  void postCommentLimitNotice_returnsSuccess_on201(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        post(urlPathEqualTo("/api/v4/projects/42/issues/5/notes"))
+            .willReturn(
+                aResponse()
+                    .withStatus(201)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"id\":202,\"body\":\"comment limit notice\"}")));
+
+    PostingResult result = buildService(wmInfo).postCommentLimitNotice("5", 10);
+
+    assertTrue(result.success());
+    assertEquals("5", result.externalIssueId());
+    assertNull(result.errorMessage());
+  }
+
+  @Test
+  void postCommentLimitNotice_returnsFailure_on404(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        post(urlPathEqualTo("/api/v4/projects/42/issues/5/notes"))
+            .willReturn(
+                aResponse().withStatus(404).withBody("{\"message\":\"404 Issue Not Found\"}")));
+
+    PostingResult result = buildService(wmInfo).postCommentLimitNotice("5", 10);
 
     assertFalse(result.success());
     assertNotNull(result.errorMessage());

--- a/observarium-jira/src/main/java/io/hephaistos/observarium/jira/JiraPostingService.java
+++ b/observarium-jira/src/main/java/io/hephaistos/observarium/jira/JiraPostingService.java
@@ -97,6 +97,7 @@ public class JiraPostingService implements PostingService, AutoCloseable {
     JsonArray fields = new JsonArray();
     fields.add("summary");
     fields.add("status");
+    fields.add("comment");
     body.add("fields", fields);
 
     String url = config.baseUrl() + "/rest/api/3/search/jql";
@@ -120,9 +121,10 @@ public class JiraPostingService implements PostingService, AutoCloseable {
       JsonObject issue = issues.get(0).getAsJsonObject();
       String key = issue.get("key").getAsString();
       String issueUrl = browseUrl(key);
+      int commentCount = extractCommentCount(issue);
 
       log.debug("Jira duplicate found: {} ({})", key, issueUrl);
-      return DuplicateSearchResult.found(key, issueUrl);
+      return DuplicateSearchResult.found(key, issueUrl, commentCount);
 
     } catch (Exception e) {
       log.error("Error searching for Jira duplicate for fingerprint {}", event.fingerprint(), e);
@@ -182,7 +184,32 @@ public class JiraPostingService implements PostingService, AutoCloseable {
   @Override
   public PostingResult commentOnIssue(String externalIssueId, ExceptionEvent event) {
     requireNonNull(externalIssueId, "externalIssueId must not be null");
-    String commentText = formatter.markdownComment(event);
+    return postComment(externalIssueId, formatter.markdownComment(event));
+  }
+
+  /**
+   * Posts a final notice comment on an existing Jira issue indicating that the configured comment
+   * limit has been reached and Observarium will stop commenting.
+   *
+   * @param externalIssueId the Jira issue key, e.g. {@code OBS-42}
+   * @param commentLimit the configured maximum number of duplicate comments
+   */
+  @Override
+  public PostingResult postCommentLimitNotice(String externalIssueId, int commentLimit) {
+    requireNonNull(externalIssueId, "externalIssueId must not be null");
+    return postComment(externalIssueId, formatter.markdownCommentLimitNotice(commentLimit));
+  }
+
+  /**
+   * Posts a comment with the given text body to an existing Jira issue.
+   *
+   * <p>The text is wrapped in an ADF paragraph node before submission. This method never throws;
+   * all failures are caught and returned as {@link PostingResult#failure(String)}.
+   *
+   * @param externalIssueId the Jira issue key, e.g. {@code OBS-42}
+   * @param commentText the plain-text or markdown comment body
+   */
+  private PostingResult postComment(String externalIssueId, String commentText) {
     JsonObject body = buildCommentBody(commentText);
     String url = config.baseUrl() + "/rest/api/3/issue/" + externalIssueId + "/comment";
 
@@ -208,6 +235,36 @@ public class JiraPostingService implements PostingService, AutoCloseable {
         Thread.currentThread().interrupt();
       }
       return PostingResult.failure("Exception commenting on Jira issue: " + e.getMessage());
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Response parsers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Extracts the comment count from a Jira issue JSON object returned by the search API.
+   *
+   * <p>The value is read from {@code issue.fields.comment.total}. Any missing or unexpected
+   * structure returns {@link DuplicateSearchResult#COMMENT_COUNT_UNKNOWN} rather than throwing.
+   */
+  private int extractCommentCount(JsonObject issue) {
+    try {
+      JsonObject fields = issue.getAsJsonObject("fields");
+      if (fields == null) {
+        return DuplicateSearchResult.COMMENT_COUNT_UNKNOWN;
+      }
+      JsonObject comment = fields.getAsJsonObject("comment");
+      if (comment == null) {
+        return DuplicateSearchResult.COMMENT_COUNT_UNKNOWN;
+      }
+      if (!comment.has("total") || comment.get("total").isJsonNull()) {
+        return DuplicateSearchResult.COMMENT_COUNT_UNKNOWN;
+      }
+      return comment.get("total").getAsInt();
+    } catch (Exception e) {
+      log.debug("Could not extract comment count from Jira issue response", e);
+      return DuplicateSearchResult.COMMENT_COUNT_UNKNOWN;
     }
   }
 

--- a/observarium-jira/src/test/java/io/hephaistos/observarium/jira/JiraPostingServiceTest.java
+++ b/observarium-jira/src/test/java/io/hephaistos/observarium/jira/JiraPostingServiceTest.java
@@ -422,6 +422,277 @@ class JiraPostingServiceTest {
   }
 
   // -------------------------------------------------------------------------
+  // findDuplicate() — comment count extraction
+  // -------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("findDuplicate() — comment count")
+  class FindDuplicateCommentCountTests {
+
+    @Test
+    @DisplayName("returns comment count from fields.comment.total when present")
+    void returnsCommentCountWhenPresent() throws Exception {
+      ExceptionEvent event = buildEvent("abc123def456xyz789");
+
+      String jiraResponse =
+          """
+                {
+                  "issues": [
+                    {
+                      "key": "OBS-42",
+                      "fields": {
+                        "summary": "some summary",
+                        "status": {"name": "Open"},
+                        "comment": {
+                          "total": 7,
+                          "comments": []
+                        }
+                      }
+                    }
+                  ],
+                  "total": 1
+                }
+                """;
+
+      JiraPostingService service =
+          new JiraPostingService(
+              config,
+              mockClient(mockResponse(200, jiraResponse)),
+              new Gson(),
+              new DefaultIssueFormatter());
+      DuplicateSearchResult result = service.findDuplicate(event);
+
+      assertTrue(result.found());
+      assertEquals("OBS-42", result.externalIssueId());
+      assertEquals(7, result.commentCount());
+    }
+
+    @Test
+    @DisplayName("returns COMMENT_COUNT_UNKNOWN when fields object is missing")
+    void returnsUnknownWhenFieldsMissing() throws Exception {
+      ExceptionEvent event = buildEvent("abc123def456xyz789");
+
+      // Issue with no "fields" object at all
+      String jiraResponse =
+          """
+                {
+                  "issues": [
+                    {
+                      "key": "OBS-42"
+                    }
+                  ],
+                  "total": 1
+                }
+                """;
+
+      JiraPostingService service =
+          new JiraPostingService(
+              config,
+              mockClient(mockResponse(200, jiraResponse)),
+              new Gson(),
+              new DefaultIssueFormatter());
+      DuplicateSearchResult result = service.findDuplicate(event);
+
+      assertTrue(result.found());
+      assertEquals(DuplicateSearchResult.COMMENT_COUNT_UNKNOWN, result.commentCount());
+    }
+
+    @Test
+    @DisplayName("returns COMMENT_COUNT_UNKNOWN when fields.comment object is missing")
+    void returnsUnknownWhenCommentObjectMissing() throws Exception {
+      ExceptionEvent event = buildEvent("abc123def456xyz789");
+
+      // Issue with "fields" but no "comment" child
+      String jiraResponse =
+          """
+                {
+                  "issues": [
+                    {
+                      "key": "OBS-42",
+                      "fields": {
+                        "summary": "some summary",
+                        "status": {"name": "Open"}
+                      }
+                    }
+                  ],
+                  "total": 1
+                }
+                """;
+
+      JiraPostingService service =
+          new JiraPostingService(
+              config,
+              mockClient(mockResponse(200, jiraResponse)),
+              new Gson(),
+              new DefaultIssueFormatter());
+      DuplicateSearchResult result = service.findDuplicate(event);
+
+      assertTrue(result.found());
+      assertEquals(DuplicateSearchResult.COMMENT_COUNT_UNKNOWN, result.commentCount());
+    }
+
+    @Test
+    @DisplayName("returns COMMENT_COUNT_UNKNOWN when fields.comment.total is absent")
+    void returnsUnknownWhenTotalFieldAbsent() throws Exception {
+      ExceptionEvent event = buildEvent("abc123def456xyz789");
+
+      // "comment" object present but "total" key is absent
+      String jiraResponse =
+          """
+                {
+                  "issues": [
+                    {
+                      "key": "OBS-42",
+                      "fields": {
+                        "comment": {
+                          "comments": []
+                        }
+                      }
+                    }
+                  ],
+                  "total": 1
+                }
+                """;
+
+      JiraPostingService service =
+          new JiraPostingService(
+              config,
+              mockClient(mockResponse(200, jiraResponse)),
+              new Gson(),
+              new DefaultIssueFormatter());
+      DuplicateSearchResult result = service.findDuplicate(event);
+
+      assertTrue(result.found());
+      assertEquals(DuplicateSearchResult.COMMENT_COUNT_UNKNOWN, result.commentCount());
+    }
+
+    @Test
+    @DisplayName("returns COMMENT_COUNT_UNKNOWN when fields.comment.total is JSON null")
+    void returnsUnknownWhenTotalIsNull() throws Exception {
+      ExceptionEvent event = buildEvent("abc123def456xyz789");
+
+      String jiraResponse =
+          """
+                {
+                  "issues": [
+                    {
+                      "key": "OBS-42",
+                      "fields": {
+                        "comment": {
+                          "total": null,
+                          "comments": []
+                        }
+                      }
+                    }
+                  ],
+                  "total": 1
+                }
+                """;
+
+      JiraPostingService service =
+          new JiraPostingService(
+              config,
+              mockClient(mockResponse(200, jiraResponse)),
+              new Gson(),
+              new DefaultIssueFormatter());
+      DuplicateSearchResult result = service.findDuplicate(event);
+
+      assertTrue(result.found());
+      assertEquals(DuplicateSearchResult.COMMENT_COUNT_UNKNOWN, result.commentCount());
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // postCommentLimitNotice()
+  // -------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("postCommentLimitNotice()")
+  class PostCommentLimitNoticeTests {
+
+    @Test
+    @DisplayName("throws NullPointerException when externalIssueId is null")
+    void throwsOnNullExternalIssueId() throws Exception {
+      JiraPostingService service =
+          new JiraPostingService(
+              config, mockClient(mockResponse(201, "{}")), new Gson(), new DefaultIssueFormatter());
+      assertThrows(NullPointerException.class, () -> service.postCommentLimitNotice(null, 10));
+    }
+
+    @Test
+    @DisplayName("returns success when Jira accepts the comment (HTTP 201)")
+    void returnsSuccessOn201() throws Exception {
+      String jiraResponse =
+          """
+                {
+                  "id": "30001",
+                  "self": "https://mycompany.atlassian.net/rest/api/3/issue/OBS-10/comment/30001"
+                }
+                """;
+
+      JiraPostingService service =
+          new JiraPostingService(
+              config,
+              mockClient(mockResponse(201, jiraResponse)),
+              new Gson(),
+              new DefaultIssueFormatter());
+      PostingResult result = service.postCommentLimitNotice("OBS-10", 5);
+
+      assertTrue(result.success());
+      assertEquals("OBS-10", result.externalIssueId());
+      assertEquals(BASE_URL + "/browse/OBS-10", result.url());
+      assertNull(result.errorMessage());
+    }
+
+    @Test
+    @DisplayName("returns failure when Jira returns HTTP 404")
+    void returnsFailureOn404() throws Exception {
+      JiraPostingService service =
+          new JiraPostingService(
+              config,
+              mockClient(mockResponse(404, "{\"errorMessages\":[\"Issue Does Not Exist\"]}")),
+              new Gson(),
+              new DefaultIssueFormatter());
+      PostingResult result = service.postCommentLimitNotice("OBS-999", 5);
+
+      assertFalse(result.success());
+      assertNotNull(result.errorMessage());
+      assertTrue(result.errorMessage().contains("404"));
+    }
+
+    @Test
+    @DisplayName("returns failure gracefully when network throws")
+    void returnsFailureOnNetworkException() throws Exception {
+      JiraPostingService service =
+          new JiraPostingService(
+              config,
+              mockClientThrowing(new RuntimeException("DNS failure")),
+              new Gson(),
+              new DefaultIssueFormatter());
+      PostingResult result = service.postCommentLimitNotice("OBS-5", 5);
+
+      assertFalse(result.success());
+      assertNotNull(result.errorMessage());
+    }
+
+    @Test
+    @DisplayName("returns failure gracefully when thread is interrupted")
+    void returnsFailureOnInterruptedException() throws Exception {
+      JiraPostingService service =
+          new JiraPostingService(
+              config,
+              mockClientThrowing(new InterruptedException("interrupted")),
+              new Gson(),
+              new DefaultIssueFormatter());
+      PostingResult result = service.postCommentLimitNotice("OBS-5", 5);
+
+      assertFalse(result.success());
+      assertNotNull(result.errorMessage());
+      assertTrue(Thread.interrupted(), "Service must restore the interrupt flag");
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // commentOnIssue()
   // -------------------------------------------------------------------------
 

--- a/observarium-jira/src/test/java/io/hephaistos/observarium/jira/JiraPostingServiceWireMockTest.java
+++ b/observarium-jira/src/test/java/io/hephaistos/observarium/jira/JiraPostingServiceWireMockTest.java
@@ -114,6 +114,25 @@ class JiraPostingServiceWireMockTest {
   }
 
   @Test
+  void findDuplicate_returnsCommentCount_fromFieldsCommentTotal(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        post(urlPathEqualTo("/rest/api/3/search/jql"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"issues\":[{\"key\":\"OBS-42\",\"fields\":"
+                            + "{\"comment\":{\"total\":3,\"comments\":[]}}}]}")));
+
+    DuplicateSearchResult result = buildService(wmInfo).findDuplicate(buildEvent());
+
+    assertTrue(result.found());
+    assertEquals("OBS-42", result.externalIssueId());
+    assertEquals(3, result.commentCount());
+  }
+
+  @Test
   void findDuplicate_returnsNotFound_whenNoIssues(WireMockRuntimeInfo wmInfo) {
     stubFor(
         post(urlPathEqualTo("/rest/api/3/search/jql"))
@@ -292,6 +311,65 @@ class JiraPostingServiceWireMockTest {
                     .withBody("{\"errorMessages\":[\"Issue OBS-42 not found\"]}")));
 
     PostingResult result = buildService(wmInfo).commentOnIssue("OBS-42", buildEvent());
+
+    assertFalse(result.success());
+    assertNotNull(result.errorMessage());
+    assertTrue(result.errorMessage().contains("404"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // postCommentLimitNotice tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void postCommentLimitNotice_postsToCommentEndpoint(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        post(urlPathEqualTo("/rest/api/3/issue/OBS-42/comment"))
+            .willReturn(
+                aResponse()
+                    .withStatus(201)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"id\":\"20002\",\"self\":\"http://example.atlassian.net/rest/api/3/issue/OBS-42/comment/20002\"}")));
+
+    buildService(wmInfo).postCommentLimitNotice("OBS-42", 5);
+
+    verify(
+        postRequestedFor(urlPathEqualTo("/rest/api/3/issue/OBS-42/comment"))
+            .withHeader("Authorization", equalTo(expectedBasicAuthHeader()))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(matchingJsonPath("$.body.type", equalTo("doc")))
+            .withRequestBody(matchingJsonPath("$.body.content[0].type", equalTo("paragraph"))));
+  }
+
+  @Test
+  void postCommentLimitNotice_returnsSuccess_on201(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        post(urlPathEqualTo("/rest/api/3/issue/OBS-42/comment"))
+            .willReturn(
+                aResponse()
+                    .withStatus(201)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"id\":\"20002\",\"self\":\"http://example.atlassian.net/rest/api/3/issue/OBS-42/comment/20002\"}")));
+
+    PostingResult result = buildService(wmInfo).postCommentLimitNotice("OBS-42", 5);
+
+    assertTrue(result.success());
+    assertEquals("OBS-42", result.externalIssueId());
+    assertNull(result.errorMessage());
+  }
+
+  @Test
+  void postCommentLimitNotice_returnsFailure_on404(WireMockRuntimeInfo wmInfo) {
+    stubFor(
+        post(urlPathEqualTo("/rest/api/3/issue/OBS-999/comment"))
+            .willReturn(
+                aResponse()
+                    .withStatus(404)
+                    .withBody("{\"errorMessages\":[\"Issue OBS-999 not found\"]}")));
+
+    PostingResult result = buildService(wmInfo).postCommentLimitNotice("OBS-999", 5);
 
     assertFalse(result.success());
     assertNotNull(result.errorMessage());

--- a/observarium-micrometer/src/main/java/io/hephaistos/observarium/micrometer/ObservariumMeterBinder.java
+++ b/observarium-micrometer/src/main/java/io/hephaistos/observarium/micrometer/ObservariumMeterBinder.java
@@ -54,6 +54,8 @@ public class ObservariumMeterBinder implements ObservariumListener, MeterBinder,
   private volatile MeterRegistry registry;
   private final ConcurrentHashMap<String, Counter> capturedCounters = new ConcurrentHashMap<>();
   private volatile Counter droppedCounter;
+  private final ConcurrentHashMap<String, Counter> commentDroppedCounters =
+      new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Timer> postingTimers = new ConcurrentHashMap<>();
 
   private final Object gaugeLock = new Object();
@@ -140,6 +142,24 @@ public class ObservariumMeterBinder implements ObservariumListener, MeterBinder,
   }
 
   @Override
+  public void onCommentDropped(String serviceName) {
+    if (registry == null) {
+      return;
+    }
+    commentDroppedCounters
+        .computeIfAbsent(
+            serviceName,
+            name ->
+                Counter.builder("observarium.comments.dropped")
+                    .description(
+                        "Duplicate comments suppressed because the issue reached its comment limit")
+                    .tag("service", name)
+                    .tags(commonTags)
+                    .register(registry))
+        .increment();
+  }
+
+  @Override
   public void onPostingCompleted(
       String serviceName, boolean duplicate, boolean success, long durationNanos) {
     if (registry == null) {
@@ -182,6 +202,9 @@ public class ObservariumMeterBinder implements ObservariumListener, MeterBinder,
       reg.remove(droppedCounter);
       droppedCounter = null;
     }
+
+    commentDroppedCounters.values().forEach(reg::remove);
+    commentDroppedCounters.clear();
 
     postingTimers.values().forEach(reg::remove);
     postingTimers.clear();

--- a/observarium-micrometer/src/test/java/io/hephaistos/observarium/micrometer/ObservariumMeterBinderTest.java
+++ b/observarium-micrometer/src/test/java/io/hephaistos/observarium/micrometer/ObservariumMeterBinderTest.java
@@ -69,6 +69,27 @@ class ObservariumMeterBinderTest {
     assertThat(counter.count()).isEqualTo(2.0);
   }
 
+  // ---------- onCommentDropped ----------
+
+  @Test
+  void onCommentDropped_incrementsCounter() {
+    binder.onCommentDropped("github");
+
+    Counter counter =
+        registry.find("observarium.comments.dropped").tag("service", "github").counter();
+    assertThat(counter).isNotNull();
+    assertThat(counter.count()).isEqualTo(1.0);
+
+    binder.onCommentDropped("github");
+    assertThat(counter.count()).isEqualTo(2.0);
+  }
+
+  @Test
+  void onCommentDropped_beforeBindTo_doesNotThrow() {
+    ObservariumMeterBinder unboundBinder = new ObservariumMeterBinder();
+    assertThatNoException().isThrownBy(() -> unboundBinder.onCommentDropped("github"));
+  }
+
   // ---------- onPostingCompleted ----------
 
   @Test
@@ -220,6 +241,19 @@ class ObservariumMeterBinderTest {
     assertThat(registry.find("observarium.exceptions.dropped").counter()).isNull();
     assertThat(registry.find("observarium.posting.duration").timer()).isNull();
     assertThat(registry.find("observarium.queue.size").gauge()).isNull();
+  }
+
+  @Test
+  void close_removesCommentDroppedCounters() {
+    binder.onCommentDropped("github");
+
+    assertThat(registry.find("observarium.comments.dropped").tag("service", "github").counter())
+        .isNotNull();
+
+    binder.close();
+
+    assertThat(registry.find("observarium.comments.dropped").tag("service", "github").counter())
+        .isNull();
   }
 
   @Test

--- a/observarium-quarkus/src/main/java/io/hephaistos/observarium/quarkus/ObservariumProducer.java
+++ b/observarium-quarkus/src/main/java/io/hephaistos/observarium/quarkus/ObservariumProducer.java
@@ -58,13 +58,22 @@ public class ObservariumProducer {
       scrubLevel = ScrubLevel.BASIC;
     }
 
+    int maxDuplicateComments = config.maxDuplicateComments();
+    if (maxDuplicateComments < -1 || maxDuplicateComments == 0) {
+      log.warn(
+          "Invalid observarium.max-duplicate-comments value '{}'; falling back to default 5",
+          maxDuplicateComments);
+      maxDuplicateComments = 5;
+    }
+
     var builder =
         Observarium.builder()
             .scrubLevel(scrubLevel)
             .fingerprinter(new DefaultExceptionFingerprinter())
             .scrubber(new DefaultDataScrubber(scrubLevel))
             .traceContextProvider(
-                new MdcTraceContextProvider(config.traceIdMdcKey(), config.spanIdMdcKey()));
+                new MdcTraceContextProvider(config.traceIdMdcKey(), config.spanIdMdcKey()))
+            .maxDuplicateComments(maxDuplicateComments);
 
     if (listenerInstance.isResolvable()) {
       builder.listener(listenerInstance.get());

--- a/observarium-quarkus/src/main/java/io/hephaistos/observarium/quarkus/ObservariumQuarkusConfig.java
+++ b/observarium-quarkus/src/main/java/io/hephaistos/observarium/quarkus/ObservariumQuarkusConfig.java
@@ -25,4 +25,7 @@ public interface ObservariumQuarkusConfig {
 
   @WithDefault("span_id")
   String spanIdMdcKey();
+
+  @WithDefault("5")
+  int maxDuplicateComments();
 }

--- a/observarium-quarkus/src/test/java/io/hephaistos/observarium/quarkus/ObservariumProducerMultiServiceTest.java
+++ b/observarium-quarkus/src/test/java/io/hephaistos/observarium/quarkus/ObservariumProducerMultiServiceTest.java
@@ -54,6 +54,7 @@ class ObservariumProducerMultiServiceTest {
     when(config.scrubLevel()).thenReturn("BASIC");
     when(config.traceIdMdcKey()).thenReturn("trace_id");
     when(config.spanIdMdcKey()).thenReturn("span_id");
+    when(config.maxDuplicateComments()).thenReturn(5);
     when(emptyInstance.iterator()).thenReturn(List.<PostingService>of().iterator());
     when(emptyListenerInstance.isResolvable()).thenReturn(false);
     when(mpConfig.getPropertyNames()).thenReturn(Set.of());

--- a/observarium-quarkus/src/test/java/io/hephaistos/observarium/quarkus/ObservariumProducerTest.java
+++ b/observarium-quarkus/src/test/java/io/hephaistos/observarium/quarkus/ObservariumProducerTest.java
@@ -58,6 +58,7 @@ class ObservariumProducerTest {
     when(config.scrubLevel()).thenReturn("BASIC");
     when(config.traceIdMdcKey()).thenReturn("trace_id");
     when(config.spanIdMdcKey()).thenReturn("span_id");
+    when(config.maxDuplicateComments()).thenReturn(5);
     when(emptyInstance.iterator()).thenReturn(List.<PostingService>of().iterator());
     when(emptyListenerInstance.isResolvable()).thenReturn(false);
 
@@ -130,6 +131,26 @@ class ObservariumProducerTest {
 
     assertThat(result).isNotNull();
     assertThat(result.config().postingServiceCount()).isZero();
+  }
+
+  @Test
+  void observarium_fallsBackToDefault_whenMaxDuplicateCommentsIsZero() {
+    when(config.maxDuplicateComments()).thenReturn(0);
+
+    Observarium result = producer.observarium(emptyInstance, emptyListenerInstance);
+
+    assertThat(result).isNotNull();
+    assertThat(result.config().maxDuplicateComments()).isEqualTo(5);
+  }
+
+  @Test
+  void observarium_fallsBackToDefault_whenMaxDuplicateCommentsIsBelowMinusOne() {
+    when(config.maxDuplicateComments()).thenReturn(-5);
+
+    Observarium result = producer.observarium(emptyInstance, emptyListenerInstance);
+
+    assertThat(result).isNotNull();
+    assertThat(result.config().maxDuplicateComments()).isEqualTo(5);
   }
 
   @Test

--- a/observarium-spring-boot/src/main/java/io/hephaistos/observarium/spring/ObservariumAutoConfiguration.java
+++ b/observarium-spring-boot/src/main/java/io/hephaistos/observarium/spring/ObservariumAutoConfiguration.java
@@ -87,7 +87,8 @@ public class ObservariumAutoConfiguration {
             .scrubLevel(properties.getScrubLevel())
             .fingerprinter(fingerprinter)
             .scrubber(scrubber)
-            .traceContextProvider(traceContextProvider);
+            .traceContextProvider(traceContextProvider)
+            .maxDuplicateComments(properties.getMaxDuplicateComments());
 
     if (listener != null) {
       builder.listener(listener);

--- a/observarium-spring-boot/src/main/java/io/hephaistos/observarium/spring/ObservariumProperties.java
+++ b/observarium-spring-boot/src/main/java/io/hephaistos/observarium/spring/ObservariumProperties.java
@@ -17,6 +17,7 @@ public class ObservariumProperties {
   private ScrubLevel scrubLevel = ScrubLevel.BASIC;
   private String traceIdMdcKey = "trace_id";
   private String spanIdMdcKey = "span_id";
+  private int maxDuplicateComments = 5;
 
   public boolean isEnabled() {
     return enabled;
@@ -48,5 +49,18 @@ public class ObservariumProperties {
 
   public void setSpanIdMdcKey(String spanIdMdcKey) {
     this.spanIdMdcKey = spanIdMdcKey;
+  }
+
+  public int getMaxDuplicateComments() {
+    return maxDuplicateComments;
+  }
+
+  public void setMaxDuplicateComments(int maxDuplicateComments) {
+    if (maxDuplicateComments < -1 || maxDuplicateComments == 0) {
+      throw new IllegalArgumentException(
+          "observarium.max-duplicate-comments must be -1 (unlimited) or a positive integer, got: "
+              + maxDuplicateComments);
+    }
+    this.maxDuplicateComments = maxDuplicateComments;
   }
 }


### PR DESCRIPTION
## Summary

- Adds a configurable per-issue comment limit (default: 5) to prevent flooding issue trackers with duplicate comments
- When the limit is reached, posts a final "Comment Limit Reached" notice, then silently drops subsequent comments
- Dropped comments are tracked via Micrometer counter `observarium.comments.dropped` with `service` tag
- Uses API-provided comment counts (GitHub `comments`, GitLab `user_notes_count`, Jira `fields.comment.total`) — survives restarts, zero extra API calls
- Fail-open: unknown comment counts (custom PostingService implementations) allow unlimited comments

## Changes

| Commit | Scope |
|--------|-------|
| `feat(core): add comment count to DuplicateSearchResult and comment limit SPI` | SPI foundation — commentCount field, IssueFormatter/PostingService default methods |
| `feat(core): implement comment limit logic in ExceptionProcessor` | Three-way decision (comment / notice / drop), ObservariumConfig, Listener callback, Builder |
| `feat(github,gitlab,jira): extract comment counts and implement limit notices` | All three posting services extract counts and implement postCommentLimitNotice |
| `feat(micrometer): add observarium.comments.dropped counter` | Lazy counter with service tag, cleanup in close() |
| `feat(spring,quarkus): add maxDuplicateComments configuration property` | `observarium.max-duplicate-comments` for Spring Boot, Quarkus config |
| `docs: document per-issue comment limit feature` | README diagram, config reference, Micrometer docs, custom integration guide |

## Configuration

```properties
# Spring Boot
observarium.max-duplicate-comments=5   # default; -1 for unlimited

# Quarkus
observarium.max-duplicate-comments=5
```

```java
// Builder API
Observarium.builder()
    .maxDuplicateComments(10)  // or -1 for unlimited
    .build();
```

## Test plan

- [ ] `./gradlew build` passes (Spotless, PMD, tests, JaCoCo)
- [ ] ExceptionProcessor: under/at/over limit branches, unknown count fail-open, unlimited config
- [ ] GitHub: comment count extraction from API, postCommentLimitNotice (Mockito + WireMock)
- [ ] Micrometer: counter increment, pre-bind safety, close cleanup
- [ ] Builder: validation rejects 0 and < -1, accepts -1 and positive values
- [ ] Quarkus: producer tests pass with mocked maxDuplicateComments

🤖 Generated with [Claude Code](https://claude.com/claude-code)