### PR TITLE
release: 0.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ configure(libraryProjects) {
     apply plugin: 'com.vanniktech.maven.publish'
 
     group = 'io.hephaistos'
-    version = '0.9.1'
+    version = '0.10.0'
 
     java {
         toolchain {
@@ -173,7 +173,7 @@ configure(demoProjects) {
     apply plugin: 'com.diffplug.spotless'
 
     group = 'io.hephaistos'
-    version = '0.9.1'
+    version = '0.10.0'
 
     java {
         toolchain {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,11 +18,11 @@ This approach works in any Java application: command-line tools, servlet contain
 
 ```groovy
 dependencies {
-    implementation 'io.hephaistos:observarium-core:0.9.1'
+    implementation 'io.hephaistos:observarium-core:0.10.0'
     // pick one or more posting service backends
-    implementation 'io.hephaistos:observarium-github:0.9.1'
+    implementation 'io.hephaistos:observarium-github:0.10.0'
     // optional: Micrometer metrics (requires micrometer-core on the classpath)
-    // implementation 'io.hephaistos:observarium-micrometer:0.9.1'
+    // implementation 'io.hephaistos:observarium-micrometer:0.10.0'
 }
 ```
 
@@ -33,19 +33,19 @@ dependencies {
   <dependency>
     <groupId>io.hephaistos</groupId>
     <artifactId>observarium-core</artifactId>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
   </dependency>
   <dependency>
     <groupId>io.hephaistos</groupId>
     <artifactId>observarium-github</artifactId>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
   </dependency>
   <!-- optional: Micrometer metrics (requires micrometer-core on the classpath) -->
   <!--
   <dependency>
     <groupId>io.hephaistos</groupId>
     <artifactId>observarium-micrometer</artifactId>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
   </dependency>
   -->
 </dependencies>
@@ -122,19 +122,19 @@ The `observarium-spring-boot` module provides auto-configuration. Drop it on the
   <dependency>
     <groupId>io.hephaistos</groupId>
     <artifactId>observarium-spring-boot</artifactId>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
   </dependency>
   <dependency>
     <groupId>io.hephaistos</groupId>
     <artifactId>observarium-github</artifactId>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
   </dependency>
   <!-- optional: Micrometer metrics — auto-configured when micrometer-core is also present -->
   <!--
   <dependency>
     <groupId>io.hephaistos</groupId>
     <artifactId>observarium-micrometer</artifactId>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
   </dependency>
   -->
 </dependencies>
@@ -144,10 +144,10 @@ The `observarium-spring-boot` module provides auto-configuration. Drop it on the
 
 ```groovy
 dependencies {
-    implementation 'io.hephaistos:observarium-spring-boot:0.9.1'
-    implementation 'io.hephaistos:observarium-github:0.9.1'
+    implementation 'io.hephaistos:observarium-spring-boot:0.10.0'
+    implementation 'io.hephaistos:observarium-github:0.10.0'
     // optional: Micrometer metrics — auto-configured when micrometer-core is also present
-    // implementation 'io.hephaistos:observarium-micrometer:0.9.1'
+    // implementation 'io.hephaistos:observarium-micrometer:0.10.0'
 }
 ```
 
@@ -209,19 +209,19 @@ The `observarium-quarkus` module provides a CDI extension. It mirrors the Spring
   <dependency>
     <groupId>io.hephaistos</groupId>
     <artifactId>observarium-quarkus</artifactId>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
   </dependency>
   <dependency>
     <groupId>io.hephaistos</groupId>
     <artifactId>observarium-github</artifactId>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
   </dependency>
   <!-- optional: Micrometer metrics — register ObservariumMeterBinder as an @ApplicationScoped bean -->
   <!--
   <dependency>
     <groupId>io.hephaistos</groupId>
     <artifactId>observarium-micrometer</artifactId>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
   </dependency>
   -->
 </dependencies>
@@ -231,10 +231,10 @@ The `observarium-quarkus` module provides a CDI extension. It mirrors the Spring
 
 ```groovy
 dependencies {
-    implementation 'io.hephaistos:observarium-quarkus:0.9.1'
-    implementation 'io.hephaistos:observarium-github:0.9.1'
+    implementation 'io.hephaistos:observarium-quarkus:0.10.0'
+    implementation 'io.hephaistos:observarium-github:0.10.0'
     // optional: Micrometer metrics — register ObservariumMeterBinder as an @ApplicationScoped bean
-    // implementation 'io.hephaistos:observarium-micrometer:0.9.1'
+    // implementation 'io.hephaistos:observarium-micrometer:0.10.0'
 }
 ```
 

--- a/docs/micrometer.md
+++ b/docs/micrometer.md
@@ -30,8 +30,8 @@ Add both `observarium-micrometer` and `micrometer-core` to your dependencies, th
 
 ```groovy
 dependencies {
-    implementation 'io.hephaistos:observarium-core:0.9.1'
-    implementation 'io.hephaistos:observarium-micrometer:0.9.1'
+    implementation 'io.hephaistos:observarium-core:0.10.0'
+    implementation 'io.hephaistos:observarium-micrometer:0.10.0'
     implementation 'io.micrometer:micrometer-core:1.14.5'
     // add a registry backend, e.g.:
     // implementation 'io.micrometer:micrometer-registry-prometheus:1.14.5'
@@ -44,12 +44,12 @@ dependencies {
 <dependency>
   <groupId>io.hephaistos</groupId>
   <artifactId>observarium-core</artifactId>
-  <version>0.9.1</version>
+  <version>0.10.0</version>
 </dependency>
 <dependency>
   <groupId>io.hephaistos</groupId>
   <artifactId>observarium-micrometer</artifactId>
-  <version>0.9.1</version>
+  <version>0.10.0</version>
 </dependency>
 <dependency>
   <groupId>io.micrometer</groupId>
@@ -96,12 +96,12 @@ Add `observarium-spring-boot`, `observarium-micrometer`, and `micrometer-core` t
 
 ```groovy
 dependencies {
-    implementation 'io.hephaistos:observarium-spring-boot:0.9.1'
-    implementation 'io.hephaistos:observarium-micrometer:0.9.1'
+    implementation 'io.hephaistos:observarium-spring-boot:0.10.0'
+    implementation 'io.hephaistos:observarium-micrometer:0.10.0'
     // micrometer-core is pulled in transitively by spring-boot-starter-actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     // pick one or more posting service backends
-    implementation 'io.hephaistos:observarium-github:0.9.1'
+    implementation 'io.hephaistos:observarium-github:0.10.0'
 }
 ```
 
@@ -111,12 +111,12 @@ dependencies {
 <dependency>
   <groupId>io.hephaistos</groupId>
   <artifactId>observarium-spring-boot</artifactId>
-  <version>0.9.1</version>
+  <version>0.10.0</version>
 </dependency>
 <dependency>
   <groupId>io.hephaistos</groupId>
   <artifactId>observarium-micrometer</artifactId>
-  <version>0.9.1</version>
+  <version>0.10.0</version>
 </dependency>
 <dependency>
   <groupId>org.springframework.boot</groupId>
@@ -158,11 +158,11 @@ Add `observarium-quarkus`, `observarium-micrometer`, and the Quarkus Micrometer 
 
 ```groovy
 dependencies {
-    implementation 'io.hephaistos:observarium-quarkus:0.9.1'
-    implementation 'io.hephaistos:observarium-micrometer:0.9.1'
+    implementation 'io.hephaistos:observarium-quarkus:0.10.0'
+    implementation 'io.hephaistos:observarium-micrometer:0.10.0'
     implementation 'io.quarkus:quarkus-micrometer'
     // pick one or more posting service backends
-    implementation 'io.hephaistos:observarium-github:0.9.1'
+    implementation 'io.hephaistos:observarium-github:0.10.0'
 }
 ```
 
@@ -172,12 +172,12 @@ dependencies {
 <dependency>
   <groupId>io.hephaistos</groupId>
   <artifactId>observarium-quarkus</artifactId>
-  <version>0.9.1</version>
+  <version>0.10.0</version>
 </dependency>
 <dependency>
   <groupId>io.hephaistos</groupId>
   <artifactId>observarium-micrometer</artifactId>
-  <version>0.9.1</version>
+  <version>0.10.0</version>
 </dependency>
 <dependency>
   <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Version bump for the 0.10.0 release, covering #23, #24, #25 and #26.

`0.9.1` → `0.10.0` in `build.gradle` (both the library and demo blocks) and in the dependency coordinates throughout `docs/getting-started.md` and `docs/micrometer.md`.

Minor rather than patch: the release adds new configuration surface and changes two existing behaviors (strict boolean parsing, and Spring ignoring `4xx` by default).

This must land before `v0.10.0` is tagged — `.github/workflows/publish.yml` refuses to publish when the tag does not match the version in `build.gradle`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017meN4nMDyk9Rt1rVSHQJBA)_